### PR TITLE
Correct reference to "protobuf_dependencies"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ you'd like support for.
 
 
 ```python
-load("@org_pubref_rules_protobuf//bzl:rules.bzl", "protobuf_dependencies")
-protobuf_dependencies(
+load("@org_pubref_rules_protobuf//bzl:rules.bzl", "protobuf_repositories")
+protobuf_repositories(
    with_go = True,
    with_java = True,
    with_cpp = True,
@@ -133,8 +133,8 @@ file.  For example, to load a different version of
 https://github.com/golang/protobuf, provide a different commit ID:
 
 ```
-load("@org_pubref_rules_protobuf//bzl:rules.bzl", "protobuf_dependencies")
-protobuf_dependencies(
+load("@org_pubref_rules_protobuf//bzl:rules.bzl", "protobuf_repositories")
+protobuf_repositories(
    with_go = True,
    overrides = {
      "com_github_golang_protobuf": {

--- a/bzl/cpp/README.md
+++ b/bzl/cpp/README.md
@@ -11,7 +11,7 @@
 Enable cpp support by loading the set of cpp dependencies in your workspace.
 
 ```python
-protobuf_dependencies(
+protobuf_repositories(
   with_cpp=True,
 )
 ```

--- a/bzl/go/README.md
+++ b/bzl/go/README.md
@@ -10,7 +10,7 @@
 Enable go support by loading the set of go dependencies in your workspace.
 
 ```python
-protobuf_dependencies(
+protobuf_repositories(
   with_go=True,
 )
 ```

--- a/bzl/grpc_gateway/README.md
+++ b/bzl/grpc_gateway/README.md
@@ -14,7 +14,7 @@
 Enable [grpc-gateway][grpc-gateway-home] support by loading the set of dependencies in your workspace.
 
 ```python
-protobuf_dependencies(
+protobuf_repositories(
   with_go=True,
   with_grpc_gateway=True,
 )

--- a/bzl/java/README.md
+++ b/bzl/java/README.md
@@ -10,7 +10,7 @@
 Enable java support by loading the set of java dependencies in your workspace.
 
 ```python
-protobuf_dependencies(
+protobuf_repositories(
   with_java=True,
 )
 ```

--- a/bzl/javanano/README.md
+++ b/bzl/javanano/README.md
@@ -10,7 +10,7 @@
 Enable java support by loading the set of java dependencies in your workspace.
 
 ```python
-protobuf_dependencies(
+protobuf_repositories(
   with_java=True,
   with_javanano=True,
   with_grpc=True,


### PR DESCRIPTION
Several of the README files referenced `protobuf_dependencies` as the
workspace function to fetch GRPC dependencies. It's actually called
`protobuf_repositories`.