### PR TITLE
Switch to new_go_repository.

### DIFF
--- a/examples/helloworld/go/client/main.go
+++ b/examples/helloworld/go/client/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"golang.org/x/net/context"
+	//"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	pb "github.com/pubref/rules_protobuf/examples/helloworld/proto/go"
@@ -46,7 +46,6 @@ import (
 	// A: go_prefix("github.com/pubref/rules_protobuf")
 	// B: path to proto file directory "//examples/helloworld/proto"
 	// C: name of BUILD target that generated the protobufs: ":go" (elide if target name is the magic "go_default_library")
-
 )
 
 const (

--- a/examples/helloworld/grpc_gateway/BUILD
+++ b/examples/helloworld/grpc_gateway/BUILD
@@ -39,6 +39,6 @@ go_test(
         ":gateway",
         "//examples/helloworld/go/server:greeter",
         "//examples/helloworld/proto:go",
-        "@com_github_golang_protobuf//:jsonpb",
+        "@com_github_golang_protobuf//jsonpb:go_default_library",
     ] + GRPC_GATEWAY_DEPS,
 )

--- a/go/BUILD
+++ b/go/BUILD
@@ -5,7 +5,7 @@ load("//protobuf:rules.bzl", "proto_language")
 proto_language(
     name = "go",
     pb_file_extensions = [".pb.go"],
-    pb_plugin = "@com_github_golang_protobuf//:protoc_gen_go",
+    pb_plugin = "@com_github_golang_protobuf//protoc-gen-go",
     pb_plugin_implements_grpc = True,
     prefix = "//:go_prefix",
 )

--- a/go/rules.bzl
+++ b/go/rules.bzl
@@ -14,13 +14,13 @@ def go_proto_repositories(
 
 
 PB_COMPILE_DEPS = [
-    "@com_github_golang_protobuf//:proto",
+    "@com_github_golang_protobuf//proto:go_default_library",
 ]
 
 GRPC_COMPILE_DEPS = PB_COMPILE_DEPS + [
     "@com_github_golang_glog//:go_default_library",
     "@org_golang_google_grpc//:go_default_library",
-    "@org_golang_x_net//:context",
+    "@org_golang_x_net//context:go_default_library",
 ]
 
 

--- a/gogo/BUILD
+++ b/gogo/BUILD
@@ -5,7 +5,7 @@ load("//protobuf:rules.bzl", "proto_language")
 proto_language(
     name = "gogo",
     pb_file_extensions = [".pb.go"],
-    pb_plugin = "@com_github_gogo_protobuf//protoc-gen-gogo:protoc-gen-gogo",
+    pb_plugin = "@com_github_gogo_protobuf//protoc-gen-gogo",
     pb_plugin_implements_grpc = True,
     prefix = "//:go_prefix",
 )

--- a/grpc_gateway/BUILD
+++ b/grpc_gateway/BUILD
@@ -9,11 +9,11 @@ proto_language(
     },
     supports_pb = False,
     supports_grpc = True,
-    grpc_plugin = "@com_github_grpc_ecosystem_grpc_gateway//:protoc-gen-grpc-gateway_bin",
+    grpc_plugin = "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway",
     grpc_plugin_name = "grpc-gateway",
     grpc_file_extensions = [".pb.gw.go"],
     grpc_inputs = [
-        "@com_github_grpc_ecosystem_grpc_gateway//:googleapi_protos",
+        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
     ],
     grpc_imports = [
         "external/com_github_grpc_ecosystem_grpc_gateway/third_party/googleapis/",
@@ -26,13 +26,13 @@ proto_language(
     name = "pb_gateway",
     pb_plugin_name = "go",
     pb_file_extensions = [".pb.go"],
-    pb_plugin = "@com_github_golang_protobuf//:protoc_gen_go",
+    pb_plugin = "@com_github_golang_protobuf//protoc-gen-go",
     pb_plugin_implements_grpc = True,
     importmap = {
         "google/api/annotations.proto": "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api",
     },
     pb_inputs = [
-        "@com_github_grpc_ecosystem_grpc_gateway//:googleapi_protos",
+        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
     ],
     pb_imports = [
         "external/com_github_grpc_ecosystem_grpc_gateway/third_party/googleapis/",
@@ -44,12 +44,12 @@ proto_language(
 proto_language(
     name = "swagger",
     pb_file_extensions = [".swagger.json"],
-    pb_plugin = "@com_github_grpc_ecosystem_grpc_gateway//:protoc-gen-swagger_bin",
+    pb_plugin = "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-swagger",
     importmap = {
         "google/api/annotations.proto": "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api",
     },
     pb_inputs = [
-        "@com_github_grpc_ecosystem_grpc_gateway//:googleapi_protos",
+        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
     ],
     pb_imports = [
         "external/com_github_grpc_ecosystem_grpc_gateway/third_party/googleapis/",

--- a/grpc_gateway/rules.bzl
+++ b/grpc_gateway/rules.bzl
@@ -9,13 +9,13 @@ def grpc_gateway_proto_repositories(
   proto_repositories(lang_requires = lang_requires, **kwargs)
 
 GRPC_GATEWAY_DEPS = [
-  "@com_github_grpc_ecosystem_grpc_gateway//:runtime",
-  "@com_github_grpc_ecosystem_grpc_gateway//:utilities",
-  "@com_github_grpc_ecosystem_grpc_gateway//:third_party/googleapis/google/api",
-  "@org_golang_google_grpc//:codes",
-  "@org_golang_google_grpc//:grpclog",
+  "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
+  "@com_github_grpc_ecosystem_grpc_gateway//utilities:go_default_library",
+  "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library",
+  "@org_golang_google_grpc//codes:go_default_library",
+  "@org_golang_google_grpc//grpclog:go_default_library",
   "@org_golang_google_grpc//:go_default_library",
-  "@org_golang_x_net//:context",
+  "@org_golang_x_net//context:go_default_library",
   "@com_github_golang_glog//:go_default_library",
 ]
 

--- a/protobuf/internal/repositories.bzl
+++ b/protobuf/internal/repositories.bzl
@@ -150,36 +150,32 @@ REPOSITORIES = {
     # ****************************************************************
 
     "com_github_golang_glog": {
-        "kind": "new_git_repository",
+        "kind": "new_go_repository",
         "name": "com_github_golang_glog",
-        "remote": "https://github.com/golang/glog.git",
+        "importpath": "github.com/golang/glog",
         "commit": "23def4e6c14b4da8ac2ed8007337bc5eb5007998", # Jan 25, 2016
-        "build_file": str(Label("//protobuf:build_file/com_github_golang_glog.BUILD")),
     },
 
     "com_github_golang_protobuf": {
-        "kind": "new_git_repository",
+        "kind": "new_go_repository",
         "name": "com_github_golang_protobuf",
-        "remote": "https://github.com/golang/protobuf.git",
+        "importpath": "github.com/golang/protobuf",
         "commit": "c3cefd437628a0b7d31b34fe44b3a7a540e98527", # Jul 27, 2016
-        "build_file": str(Label("//protobuf:build_file/com_github_golang_protobuf.BUILD")),
     },
 
     "org_golang_google_grpc": {
-        "kind": "new_git_repository",
+        "kind": "new_go_repository",
         "name": "org_golang_google_grpc",
-        "remote": "https://github.com/grpc/grpc-go.git",
+        "importpath": "github.com/grpc/grpc-go",
         #"commit": "13edeeffdea7a41d5aad96c28deb4c7bd01a9397", #v1.0.0
         "tag": "v1.0.0",
-        "build_file": str(Label("//protobuf:build_file/org_golang_google_grpc.BUILD")),
     },
 
     "org_golang_x_net": {
-        "kind": "new_git_repository",
+        "kind": "new_go_repository",
         "name": "org_golang_x_net",
-        "remote": "https://github.com/golang/net.git",
+        "importpath": "github.com/golang/net",
         "commit": "2a35e686583654a1b89ca79c4ac78cb3d6529ca3",
-        "build_file": str(Label("//protobuf:build_file/org_golang_x_net.BUILD")),
     },
 
     # ****************************************************************
@@ -187,11 +183,10 @@ REPOSITORIES = {
     # ****************************************************************
 
     "com_github_grpc_ecosystem_grpc_gateway": {
-        "kind": "new_git_repository",
+        "kind": "new_go_repository",
         "name": "com_github_grpc_ecosystem_grpc_gateway",
-        "remote": "https://github.com/grpc-ecosystem/grpc-gateway.git",
+        "importpath": "github.com/grpc-ecosystem/grpc-gateway",
         "commit": "ccd4e6b091a44f9f6b32848ffc63b3e8f8e26092",
-        "build_file": str(Label("//protobuf:build_file/com_github_grpc_ecosystem_grpc_gateway.BUILD")),
     },
 
     # ****************************************************************


### PR DESCRIPTION
DO NOT MERGE. Right now this DOESN'T WORK. DO NOT MERGE.

This means that the build files for golang dependences are automatically
generated. This should make it possible for anyone who is using Gazelle
to generate their build files to use rules_protobuf (assuing the
versions of rules_go match).

However...

This might be an issue cause I'm developing on a mac, but I am getting this error:

ERROR: /Users/achew22/Projects/rules_protobuf/third_party/protoc_gen_python_grpc/BUILD:5:1: no such package '@protoc_gen_python_grpc_macosx//file': error loading package 'external': The repository named 'protoc_gen_python_grpc_macosx' could not be resolved and referenced by '//third_party/protoc_gen_python_grpc:protoc_gen_python_grpc_bin'.

Do you know why I'm getting this error?

This is blocking me from building anything at all so I can't tell if my change works at all but it seems in the ballpark.