### PR TITLE
Address sandbox issues on linux

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,7 +34,7 @@ closure_repositories()
 
 git_repository(
     name = "io_bazel_rules_dotnet",
-    commit = "9283e4596fbadd7fed237b5c462dfd687c15d301",
+    commit = "ebc7c1cb61d45bd57042c60b6bfabdfff4979466",
     remote = "https://github.com/bazelbuild/rules_dotnet.git",
 )
 

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -14,5 +14,6 @@ proto_language(
     grpc_plugin_name = "grpc_cpp",
     grpc_compile_deps = [
         '@com_github_grpc_grpc//:grpc++',
+        '@com_github_grpc_grpc//:grpc++_reflection',
     ],
 )

--- a/cpp/deps.bzl
+++ b/cpp/deps.bzl
@@ -5,7 +5,7 @@ DEPS = {
         "rule": "git_repository",
         "remote": "https://github.com/grpc/grpc.git",
         "init_submodules": True,
-        "commit": "673fa6c88b8abd542ae50c4480de92880a1e4777",
+        "commit": "83f8bc5b807b717c2eb018fcb0874444843e25fb",
     },
 
     # Hooray! The boringssl team provides a "master-with-bazel" branch
@@ -44,17 +44,10 @@ DEPS = {
         "actual": "@com_github_google_protobuf//:protobuf",
     },
 
-    # grpc++ requires nanobp (and now has a BUILD file!)
-    "com_github_nanopb_nanopb": {
-        "rule": "git_repository",
-        "remote": "https://github.com/nanopb/nanopb.git",
-        "commit": "91bb64a47b36b112c9b22391ef76fab29cf2cffc", # Sep 1 2016
-    },
-
     # grpc++ expects //external:nanopb
     "nanopb": {
         "rule": "bind",
-        "actual": "@com_github_nanopb_nanopb//:nanopb",
+        "actual": "@com_github_grpc_grpc//third_party/nanopb",
     },
 
     # Bind the executable cc_binary grpc plugin into

--- a/cpp/rules.bzl
+++ b/cpp/rules.bzl
@@ -9,7 +9,6 @@ def cpp_proto_repositories(
       "com_github_grpc_grpc",
       "com_github_madler_zlib",
       "zlib",
-      "com_github_nanopb_nanopb",
       "nanopb",
       "boringssl",
       "libssl",
@@ -27,6 +26,7 @@ PB_COMPILE_DEPS = [
 
 GRPC_COMPILE_DEPS = PB_COMPILE_DEPS + [
     "@com_github_grpc_grpc//:grpc++",
+    "@com_github_grpc_grpc//:grpc++_reflection",
 ]
 
 def cpp_proto_compile(langs = [str(Label("//cpp"))], **kwargs):

--- a/examples/wkt/go/BUILD
+++ b/examples/wkt/go/BUILD
@@ -16,6 +16,9 @@ go_proto_library(
     imports = [
         "external/com_github_google_protobuf/src",
     ],
+    inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
     protos = ["wkt.proto"],
     deps = [
         "@com_github_golang_protobuf//protoc-gen-go/descriptor:go_default_library",
@@ -27,6 +30,7 @@ go_proto_library(
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
     ],
+    verbose = 3,
 )
 
 go_test(

--- a/grpc_gateway/BUILD
+++ b/grpc_gateway/BUILD
@@ -14,6 +14,7 @@ proto_language(
     grpc_file_extensions = [".pb.gw.go"],
     grpc_inputs = [
         "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
+        "@com_github_google_protobuf//:well_known_protos",
     ],
     grpc_imports = [
         "external/com_github_google_protobuf/src/",
@@ -33,6 +34,7 @@ proto_language(
     },
     pb_inputs = [
         "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
+        "@com_github_google_protobuf//:well_known_protos",
     ],
     pb_imports = [
         "external/com_github_google_protobuf/src/",
@@ -50,6 +52,7 @@ proto_language(
     },
     pb_inputs = [
         "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
+        "@com_github_google_protobuf//:well_known_protos",
     ],
     pb_imports = [
         "external/com_github_google_protobuf/src/",

--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -359,7 +359,7 @@ def _compile(ctx, unit):
   transitive_units = set()
   for u in unit.data.transitive_units:
     transitive_units = transitive_units | u.inputs
-  inputs = list(unit.inputs | transitive_units)
+  inputs = list(unit.inputs | transitive_units) + [unit.compiler]
   outputs = list(unit.outputs)
 
   cmds = [" ".join(protoc_cmd)]

--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -356,7 +356,10 @@ def _compile(ctx, unit):
   protoc_cmd = [protoc] + list(unit.args) + imports + srcs
   manifest = [f.short_path for f in unit.outputs]
 
-  inputs = list(unit.inputs)
+  transitive_units = set()
+  for u in unit.data.transitive_units:
+    transitive_units = transitive_units | u.inputs
+  inputs = list(unit.inputs | transitive_units)
   outputs = list(unit.outputs)
 
   cmds = [" ".join(protoc_cmd)]
@@ -454,7 +457,7 @@ def _proto_compile_impl(ctx):
   builder = {
     "args": [], # list of string
     "imports": ctx.attr.imports + ["."],
-    "inputs": ctx.files.protos,
+    "inputs": ctx.files.protos + ctx.files.inputs,
     "outputs": [],
   }
 


### PR DESCRIPTION
- Removes external nanopb dependency, use the one from grpc/third party instead (fixes #7).
- Propogate inputs better to make visible with linux sandbox.
- Require grpc++ reflection API as compile dependency.
- Require well_known_protos for grpc_gateway to make visible by sandbox.
- Updates grpc/grpc to version with grpc++/ext protobuf regenerated.
- Updates rules_dotnet to avoid cfg warnings.
