### PR TITLE
Clarifies the use of greeter_client.py with grpc.

### DIFF
--- a/examples/helloworld/python/BUILD
+++ b/examples/helloworld/python/BUILD
@@ -1,9 +1,16 @@
 package(default_visibility = ["//visibility:public"])
 
+# Note: python grpc functionality in rules_protobuf is very
+# experimental.  There is currently no support for fetching the
+# platform-specific grpcio wheel from pypi within bazel.  To try this,
+# you'll have to `pip install grpcio` locally so it's available for
+# import.
+
 py_binary(
     name = "greeter_client",
     srcs = [
         "greeter_client.py",
+        "//examples/proto:py",
         "//examples/helloworld/proto:py",
     ],
 )

--- a/examples/helloworld/python/greeter_client.py
+++ b/examples/helloworld/python/greeter_client.py
@@ -33,7 +33,8 @@ from __future__ import print_function
 
 import grpc
 
-import helloworld_pb2
+#import helloworld_pb2
+from examples.helloworld.proto import helloworld_pb2
 
 def run():
   channel = grpc.insecure_channel('localhost:50051')


### PR DESCRIPTION
Closes #29, sort of.