### PR TITLE
zlib must use -isystem

### DIFF
--- a/protobuf/build_file/com_github_madler_zlib.BUILD
+++ b/protobuf/build_file/com_github_madler_zlib.BUILD
@@ -38,6 +38,9 @@ cc_library(
         "zlib.h",
         "zutil.h",
     ],
+    includes = [
+        ".",
+    ],
     copts = [
         "-Wno-unused-variable",
         "-Wno-implicit-function-declaration",


### PR DESCRIPTION
Without the includes clause grpc fails to build, as zlib is included as <zlib.h> and not "zlib.h"