### PR TITLE
automatically export //java:grpc_compiletime_deps when with_Grpc = true

### DIFF
--- a/examples/helloworld/java/org/pubref/rules_protobuf/examples/helloworld/client/BUILD
+++ b/examples/helloworld/java/org/pubref/rules_protobuf/examples/helloworld/client/BUILD
@@ -27,7 +27,7 @@ java_library(
     name = "client",
     srcs = ["HelloWorldClient.java"],
     deps = [
+        # This rule automatically exports //java:grpc_compiletime_deps.
         "//examples/helloworld/proto:java",
-        "//java:grpc_compiletime_deps",
     ],
 )

--- a/examples/helloworld/java/org/pubref/rules_protobuf/examples/helloworld/server/BUILD
+++ b/examples/helloworld/java/org/pubref/rules_protobuf/examples/helloworld/server/BUILD
@@ -28,7 +28,7 @@ java_library(
     name = "server",
     srcs = ["HelloWorldServer.java"],
     deps = [
+        # This rule automatically exports //java:grpc_compiletime_deps.
         "//examples/helloworld/proto:java",
-        "//java:grpc_compiletime_deps",
     ],
 )

--- a/java/README.md
+++ b/java/README.md
@@ -41,6 +41,8 @@ Target //:protos up-to-date:
 ## java\_proto\_library
 
 Pass the set of protobuf source files to the `protos` attribute.
+When depending on a java_proto_library target, it will automatically export
+`@org_pubref_rules_protobuf//java:grpc_compiletime_deps` for you.
 
 ```python
 load("@org_pubref_rules_protobuf//java:rules.bzl", "java_proto_library")

--- a/java/rules.bzl
+++ b/java/rules.bzl
@@ -119,9 +119,14 @@ def java_proto_library(
     jars = [name + "_compile_deps"],
   )
 
+  java_exports = []
+  if with_grpc:
+    java_exports.append(str(Label("//java:grpc_compiletime_deps")))
+
   native.java_library(
     name = name,
     srcs = srcs + [name + ".pb"],
+    exports = java_exports,
     deps = list(set(deps + proto_deps + [name + "_compile_imports"])),
     **kwargs)
 


### PR DESCRIPTION
This makes it easier on users to not have to remember to import //java:grpc_compiletime_deps on their own.