### PR TITLE
Adds `args` string_list option to proto_compile

### DIFF
--- a/examples/extra_args/BUILD
+++ b/examples/extra_args/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+# https://github.com/pubref/rules_protobuf/issues/57
+
+load("@org_pubref_rules_protobuf//protobuf:rules.bzl", "proto_compile")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+
+filegroup(
+    name = "protos",
+    srcs = ["person.proto"],
+)
+
+proto_compile(
+    name = "person_proto",
+    protos = ["person.proto"],
+    args = [
+        "--include_imports",
+        "--include_source_info",
+    ],
+    verbose = 0,
+)
+
+# pkg_tar rule is used in this example to provide a sink for the
+# descriptor file, forcing bazel to actually execute upstream
+# dependent rules.
+pkg_tar(
+    name = "person_tar",
+    files = [
+        ":person_proto.descriptor_set",
+    ]
+)

--- a/examples/extra_args/BUILD
+++ b/examples/extra_args/BUILD
@@ -5,7 +5,6 @@ package(default_visibility = ["//visibility:public"])
 load("@org_pubref_rules_protobuf//protobuf:rules.bzl", "proto_compile")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
-
 filegroup(
     name = "protos",
     srcs = ["person.proto"],
@@ -19,6 +18,10 @@ proto_compile(
         "--include_source_info",
     ],
     verbose = 0,
+
+    # For well-known protos, if needed
+    imports = ["external/com_github_google_protobuf/src"],
+    inputs = ["@com_github_google_protobuf//:well_known_protos"],
 )
 
 # pkg_tar rule is used in this example to provide a sink for the

--- a/examples/extra_args/person.proto
+++ b/examples/extra_args/person.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Person {
+  string name = 1;
+}

--- a/examples/extra_args/person.proto
+++ b/examples/extra_args/person.proto
@@ -1,5 +1,26 @@
 syntax = "proto3";
 
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/compiler/plugin.proto";
+
 message Person {
   string name = 1;
+  google.protobuf.FileDescriptorProto file = 2;
+  google.protobuf.Any any = 3;
+  google.protobuf.Duration duration = 4;
+  google.protobuf.Timestamp ts = 5;
+  google.protobuf.Empty empty = 6;
+  google.protobuf.Struct struct = 7;
+  google.protobuf.BytesValue bytes_wrapper = 8;
+  google.protobuf.compiler.CodeGeneratorRequest code_generator_request = 9;
+}
+
+extend google.protobuf.MessageOptions {
+  string my_option = 10001;
 }

--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -115,6 +115,7 @@ proto_compile(
 | `importmap` | `string_dict` | (golang specific) Optional mappings for the protoc-gen-go plugin.  | `{}` |
 | `root` | `string` | An optional path that shifts the directory scope of the computed execution root  | `""` |
 | `protoc` | executable `label` | Optional override to the default protoc binary tool. | `//external:protoc` |
+| `args` | `string_list` | Optional extra arguments for the protoc command, such as `--include_source_info`. | `[]` |
 | `output_to_workspace` | `boolean` | Optional flag.  Under normal operation, generated code is placed in the bazel sandbox and does not need to be checked in into version control.  However, your requirements may be such that is necessary to check these generated files in.  Setting this flag to `True` will emit generated `*.pb.*` files into in your workspace alongside the `*.proto` source files.  Please make sure you're sure you want to do this as it has the potential for unwanted overwrite of source files.  | `False` |
 
 ---

--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -519,7 +519,7 @@ def _proto_compile_impl(ctx):
     compiler = ctx.executable.protoc,
     data = data,
     transitive_mappings = builder.get("transitive_mappings", {}),
-    args = set(builder["args"]),
+    args = set(builder["args"] + ctx.attr.args),
     imports = set(builder["imports"]),
     inputs = set(builder["inputs"]),
     outputs = set(builder["outputs"] + [ctx.outputs.descriptor_set]),
@@ -545,10 +545,11 @@ def _proto_compile_impl(ctx):
 proto_compile = rule(
   implementation = _proto_compile_impl,
   attrs = {
+    "args": attr.string_list(),
     "langs": attr.label_list(
       providers = ["proto_language"],
       allow_files = False,
-      mandatory = True,
+      mandatory = False,
     ),
     "protos": attr.label_list(
       allow_files = FileType([".proto"]),


### PR DESCRIPTION
* Also makes the `langs` attribute non-mandatory.

Closes #57