### PR TITLE
Adds -request_context option to grpc_gateway_library

### DIFF
--- a/examples/helloworld/grpc_gateway/BUILD
+++ b/examples/helloworld/grpc_gateway/BUILD
@@ -25,7 +25,6 @@ grpc_gateway_binary(
     srcs = ["greeter.go"],
     proto_label = "gateway",
     protos = ["helloworld.proto"],
-    #request_context = False, # if you require go < 1.7
 )
 
 go_test(

--- a/examples/helloworld/grpc_gateway/BUILD
+++ b/examples/helloworld/grpc_gateway/BUILD
@@ -25,6 +25,7 @@ grpc_gateway_binary(
     srcs = ["greeter.go"],
     proto_label = "gateway",
     protos = ["helloworld.proto"],
+    #request_context = False, # if you require go < 1.7
 )
 
 go_test(

--- a/grpc_gateway/README.md
+++ b/grpc_gateway/README.md
@@ -93,7 +93,7 @@ This rule includes all common `_library` attributes in addition to:
 | `stderrthreshold` | `boolean` | Emit logging to stderr rather than a file. | `True` |
 | `stderrthreshold` | `int` | See grpc_gateway docs. | `0` |
 | `log_backtrace_at` | `int` | See grpc_gateway docs. | `0` |
-| `request_context` | `boolean` | See grpc_gateway docs. | `True` |
+| `request_context` | `boolean` | See grpc_gateway docs. | `False` |
 
 ## grpc_gateway_binary
 

--- a/grpc_gateway/README.md
+++ b/grpc_gateway/README.md
@@ -93,6 +93,7 @@ This rule includes all common `_library` attributes in addition to:
 | `stderrthreshold` | `boolean` | Emit logging to stderr rather than a file. | `True` |
 | `stderrthreshold` | `int` | See grpc_gateway docs. | `0` |
 | `log_backtrace_at` | `int` | See grpc_gateway docs. | `0` |
+| `request_context` | `boolean` | See grpc_gateway docs. | `True` |
 
 ## grpc_gateway_binary
 

--- a/grpc_gateway/deps.bzl
+++ b/grpc_gateway/deps.bzl
@@ -2,7 +2,7 @@ DEPS = {
     "com_github_grpc_ecosystem_grpc_gateway": {
         "rule": "new_go_repository",
         "importpath": "github.com/grpc-ecosystem/grpc-gateway",
-        "commit": "372984b6925646ccd2e7987037106b4337def2a9",
+        "commit": "686368427ddb9a51628d63db6c74fbc96a206e1f", # Jan 24, 2017
     },
 
 }

--- a/grpc_gateway/rules.bzl
+++ b/grpc_gateway/rules.bzl
@@ -55,7 +55,7 @@ def grpc_gateway_proto_library(
     log_dir = None,
     log_level = None,
     import_prefix = None,
-    request_context = True,
+    request_context = False,
 
     **kwargs):
 

--- a/grpc_gateway/rules.bzl
+++ b/grpc_gateway/rules.bzl
@@ -55,6 +55,7 @@ def grpc_gateway_proto_library(
     log_dir = None,
     log_level = None,
     import_prefix = None,
+    request_context = True,
 
     **kwargs):
 
@@ -100,6 +101,8 @@ def grpc_gateway_proto_library(
     pbgw_opts += ["v=%s" % log_level]
   if import_prefix:
     pbgw_opts += ["import_prefix=%s" % import_prefix]
+  if request_context:
+    pbgw_opts += ["request_context=true"]
 
   pbgw_args += {
     "name": name + ".gw",
@@ -110,8 +113,8 @@ def grpc_gateway_proto_library(
     "imports": imports,
     "importmap": importmap,
     "inputs": inputs,
-    "pb_options": pb_options + pbgw_opts,
-    "grpc_options": grpc_options,
+    "pb_options": pb_options,
+    "grpc_options": grpc_options + pbgw_opts,
     "output_to_workspace": output_to_workspace,
     "verbose": verbose,
   }

--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -491,8 +491,6 @@ def _proto_compile_impl(ctx):
     builder[lang.name + "_pb_options"] = lang.pb_options + data.pb_options
     builder[lang.name + "_grpc_options"] = lang.grpc_options + data.grpc_options
 
-    #print("grpc_inputs %s" % ctx.attr.grpc_inputs)
-
   _build_descriptor_set(data, builder)
 
   for run in runs:


### PR DESCRIPTION
1. Adds support for the new `-request_context` option to `grpc_gateway_proto_library`,
2. Updates grpc_gateway to 686368427ddb9a51628d63db6c74fbc96a206e1f.
3. Fixes a larger bug in propagation of all grpc_gateway options.

@AmandaCameron @achew22 PTAL, specifically: should the default behavior be `request_context=True`?  Given that I figure most people considering rules_protobuf with grpc_gateway will be using a recent version of go, I opted to make this the default.

FIxes #60