### PR TITLE
Re-format Bazel build files \w buildifier

### DIFF
--- a/closure/BUILD
+++ b/closure/BUILD
@@ -4,23 +4,23 @@ load("//protobuf:rules.bzl", "proto_language")
 
 proto_language(
     name = "closure",
-    pb_plugin_name = "js",
+    output_to_library = True,
     pb_file_extensions = [".js"],
     pb_options = [
         "import_style=closure",
         "error_on_name_conflict",
         "binary",
     ],
-    output_to_library = True,
+    pb_plugin_name = "js",
 )
 
 proto_language(
     name = "browser",
-    pb_plugin_name = "js",
     pb_file_extensions = ["_pb.js"],
     pb_options = [
         "import_style=browser",
         "error_on_name_conflict",
         "binary",
     ],
+    pb_plugin_name = "js",
 )

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -4,16 +4,22 @@ load("//protobuf:rules.bzl", "proto_language")
 
 proto_language(
     name = "cpp",
-    pb_file_extensions = [".pb.h", ".pb.cc"],
+    grpc_compile_deps = [
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_github_grpc_grpc//:grpc++_reflection",
+    ],
+    grpc_file_extensions = [
+        ".grpc.pb.h",
+        ".grpc.pb.cc",
+    ],
+    grpc_plugin = "//external:protoc_gen_grpc_cpp",
+    grpc_plugin_name = "grpc_cpp",
     pb_compile_deps = [
         "//external:protobuf_clib",
     ],
-    supports_grpc = True,
-    grpc_file_extensions = [".grpc.pb.h", ".grpc.pb.cc"],
-    grpc_plugin = "//external:protoc_gen_grpc_cpp",
-    grpc_plugin_name = "grpc_cpp",
-    grpc_compile_deps = [
-        '@com_github_grpc_grpc//:grpc++',
-        '@com_github_grpc_grpc//:grpc++_reflection',
+    pb_file_extensions = [
+        ".pb.h",
+        ".pb.cc",
     ],
+    supports_grpc = True,
 )

--- a/csharp/BUILD
+++ b/csharp/BUILD
@@ -4,17 +4,17 @@ load("//protobuf:rules.bzl", "proto_language")
 
 proto_language(
     name = "csharp",
-    pb_file_extensions = [".cs"],
+    grpc_compile_deps = [
+        "@nuget_grpc//:core",
+    ],
+    grpc_file_extensions = ["Grpc.cs"],
+    grpc_plugin = "@com_github_grpc_grpc//:grpc_csharp_plugin",
+    grpc_plugin_name = "grpc_csharp",
     output_file_style = "pascal",
     output_to_libdir = True,
     pb_compile_deps = [
         "@nuget_google_protobuf//:libnet45",
     ],
+    pb_file_extensions = [".cs"],
     supports_grpc = True,
-    grpc_file_extensions = ["Grpc.cs"],
-    grpc_plugin = "@com_github_grpc_grpc//:grpc_csharp_plugin",
-    grpc_plugin_name = "grpc_csharp",
-    grpc_compile_deps = [
-        "@nuget_grpc//:core",
-    ],
 )

--- a/examples/extra_args/BUILD
+++ b/examples/extra_args/BUILD
@@ -12,16 +12,16 @@ filegroup(
 
 proto_compile(
     name = "person_proto",
-    protos = ["person.proto"],
     args = [
         "--include_imports",
         "--include_source_info",
     ],
-    verbose = 0,
 
     # For well-known protos, if needed
     imports = ["external/com_github_google_protobuf/src"],
     inputs = ["@com_github_google_protobuf//:well_known_protos"],
+    protos = ["person.proto"],
+    verbose = 0,
 )
 
 # pkg_tar rule is used in this example to provide a sink for the
@@ -31,5 +31,5 @@ pkg_tar(
     name = "person_tar",
     files = [
         ":person_proto.descriptor_set",
-    ]
+    ],
 )

--- a/examples/helloworld/python/BUILD
+++ b/examples/helloworld/python/BUILD
@@ -10,8 +10,8 @@ py_binary(
     name = "greeter_client",
     srcs = [
         "greeter_client.py",
-        "//examples/proto:py",
         "//examples/helloworld/proto:py",
+        "//examples/proto:py",
     ],
 )
 
@@ -23,7 +23,7 @@ py_binary(
 py_test(
     name = "test_greeter_server",
     srcs = ["test_greeter_server.py"],
-    deps = [":grpc_server"]
+    deps = [":grpc_server"],
 )
 
 # This library is necessary for creating py_test cases o/w if we explicitly add
@@ -34,7 +34,7 @@ py_library(
     name = "grpc_server",
     srcs = [
         "greeter_server.py",
-        "//examples/proto:py",
         "//examples/helloworld/proto:py",
-    ]
+        "//examples/proto:py",
+    ],
 )

--- a/examples/wkt/go/BUILD
+++ b/examples/wkt/go/BUILD
@@ -20,6 +20,7 @@ go_proto_library(
         "@com_github_google_protobuf//:well_known_protos",
     ],
     protos = ["wkt.proto"],
+    verbose = 3,
     deps = [
         "@com_github_golang_protobuf//protoc-gen-go/descriptor:go_default_library",
         "@com_github_golang_protobuf//protoc-gen-go/plugin:go_default_library",
@@ -30,7 +31,6 @@ go_proto_library(
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
     ],
-    verbose = 3,
 )
 
 go_test(

--- a/grpc_gateway/BUILD
+++ b/grpc_gateway/BUILD
@@ -4,60 +4,60 @@ load("//protobuf:rules.bzl", "proto_language")
 
 proto_language(
     name = "grpc_gateway",
-    importmap = {
-        "google/api/annotations.proto": "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api",
-    },
-    supports_pb = False,
-    supports_grpc = True,
-    grpc_plugin = "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway",
-    grpc_plugin_name = "grpc-gateway",
     grpc_file_extensions = [".pb.gw.go"],
-    grpc_inputs = [
-        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
-        "@com_github_google_protobuf//:well_known_protos",
-    ],
     grpc_imports = [
         "external/com_github_google_protobuf/src/",
         "external/com_github_grpc_ecosystem_grpc_gateway/third_party/googleapis/",
     ],
+    grpc_inputs = [
+        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
+    grpc_plugin = "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway",
+    grpc_plugin_name = "grpc-gateway",
+    importmap = {
+        "google/api/annotations.proto": "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api",
+    },
     prefix = "//:go_prefix",
+    supports_grpc = True,
+    supports_pb = False,
 )
 
 proto_language(
     name = "pb_gateway",
-    pb_plugin_name = "go",
-    pb_file_extensions = [".pb.go"],
-    pb_plugin = "@com_github_golang_protobuf//protoc-gen-go",
-    pb_plugin_implements_grpc = True,
     importmap = {
         "google/api/annotations.proto": "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api",
     },
-    pb_inputs = [
-        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
-        "@com_github_google_protobuf//:well_known_protos",
-    ],
+    pb_file_extensions = [".pb.go"],
     pb_imports = [
         "external/com_github_google_protobuf/src/",
         "external/com_github_grpc_ecosystem_grpc_gateway/third_party/googleapis/",
     ],
+    pb_inputs = [
+        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
+    pb_plugin = "@com_github_golang_protobuf//protoc-gen-go",
+    pb_plugin_implements_grpc = True,
+    pb_plugin_name = "go",
     prefix = "//:go_prefix",
 )
 
 proto_language(
     name = "swagger",
-    pb_file_extensions = [".swagger.json"],
-    pb_plugin = "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-swagger",
     importmap = {
         "google/api/annotations.proto": "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api",
     },
-    pb_inputs = [
-        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
-        "@com_github_google_protobuf//:well_known_protos",
-    ],
+    pb_file_extensions = [".swagger.json"],
     pb_imports = [
         "external/com_github_google_protobuf/src/",
         "external/com_github_grpc_ecosystem_grpc_gateway/third_party/googleapis/",
     ],
-    supports_grpc = True,
+    pb_inputs = [
+        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
+    pb_plugin = "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-swagger",
     prefix = "//:go_prefix",
+    supports_grpc = True,
 )

--- a/java/BUILD
+++ b/java/BUILD
@@ -5,15 +5,6 @@ load("//java:rules.bzl", "java_proto_language_import")
 
 proto_language(
     name = "java",
-    output_to_jar = True,
-    pb_file_extensions = [],
-    pb_compile_deps = [
-        "@com_google_guava_guava//jar",
-        "@com_google_protobuf_protobuf_java//jar",
-    ],
-    pb_runtime_deps = [],
-    supports_grpc = True,
-    grpc_plugin = ":protoc_gen_grpc_java_bin",
     grpc_compile_deps = [
         "@io_grpc_grpc_core//jar",
         "@io_grpc_grpc_protobuf//jar",
@@ -21,6 +12,7 @@ proto_language(
         "@io_grpc_grpc_auth//jar",
         "@com_google_auth_google_auth_library_credentials//jar",
     ],
+    grpc_plugin = ":protoc_gen_grpc_java_bin",
     grpc_runtime_deps = [
         "@io_grpc_grpc_netty//jar",
         "@io_grpc_grpc_context//jar",
@@ -33,6 +25,14 @@ proto_language(
         "@io_netty_netty_transport//jar",
         "@io_grpc_grpc_protobuf_lite//jar",
     ],
+    output_to_jar = True,
+    pb_compile_deps = [
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf_protobuf_java//jar",
+    ],
+    pb_file_extensions = [],
+    pb_runtime_deps = [],
+    supports_grpc = True,
 )
 
 java_proto_language_import(
@@ -48,20 +48,6 @@ java_proto_language_import(
 
 proto_language(
     name = "nano",
-    output_to_jar = True,
-    pb_plugin_name = "javanano",
-    pb_file_extensions = [],
-    supports_grpc = True,
-    pb_compile_deps = [
-        "@com_google_guava_guava//jar",
-        "@com_google_protobuf_protobuf_java//jar",
-        "@com_google_protobuf_nano_protobuf_javanano//jar",
-    ],
-    pb_options = [
-        "ignore_services=true"
-    ],
-    pb_runtime_deps = [],
-    grpc_plugin = ":protoc_gen_grpc_java_bin",
     grpc_compile_deps = [
         "@io_grpc_grpc_core//jar",
         "@io_grpc_grpc_protobuf//jar",
@@ -69,6 +55,7 @@ proto_language(
         "@com_google_protobuf_nano_protobuf_javanano//jar",
         "@io_grpc_grpc_protobuf_nano//jar",
     ],
+    grpc_plugin = ":protoc_gen_grpc_java_bin",
     grpc_runtime_deps = [
         "@io_grpc_grpc_netty//jar",
         "@io_grpc_grpc_protobuf_lite//jar",
@@ -80,8 +67,20 @@ proto_language(
         "@io_netty_netty_resolver//jar",
         "@io_netty_netty_transport//jar",
     ],
+    output_to_jar = True,
+    pb_compile_deps = [
+        "@com_google_guava_guava//jar",
+        "@com_google_protobuf_protobuf_java//jar",
+        "@com_google_protobuf_nano_protobuf_javanano//jar",
+    ],
+    pb_file_extensions = [],
+    pb_options = [
+        "ignore_services=true",
+    ],
+    pb_plugin_name = "javanano",
+    pb_runtime_deps = [],
+    supports_grpc = True,
 )
-
 
 genrule(
     name = "protoc_gen_grpc_java_bin",

--- a/node/BUILD
+++ b/node/BUILD
@@ -4,14 +4,14 @@ load("//protobuf:rules.bzl", "proto_language")
 
 proto_language(
     name = "node",
-    pb_plugin_name = "js",
+    grpc_file_extensions = ["_grpc_pb.js"],
+    grpc_plugin = "@com_github_grpc_grpc//:grpc_node_plugin",
+    grpc_plugin_name = "grpc_node",
     pb_file_extensions = ["_pb.js"],
     pb_options = [
         "import_style=commonjs",
         "binary",
     ],
+    pb_plugin_name = "js",
     supports_grpc = True,
-    grpc_file_extensions = ["_grpc_pb.js"],
-    grpc_plugin = "@com_github_grpc_grpc//:grpc_node_plugin",
-    grpc_plugin_name = "grpc_node",
 )

--- a/objc/BUILD
+++ b/objc/BUILD
@@ -4,10 +4,16 @@ load("//protobuf:rules.bzl", "proto_language")
 
 proto_language(
     name = "objc",
-    pb_file_extensions = [".pbobjc.h", ".pbobjc.m"],
-    output_file_style = "capitalize",
-    supports_grpc = True,
-    grpc_file_extensions = [".pbrpc.h", ".pbrpc.m"],
+    grpc_file_extensions = [
+        ".pbrpc.h",
+        ".pbrpc.m",
+    ],
     grpc_plugin = "//external:protoc_gen_grpc_objc",
     grpc_plugin_name = "grpc_objc",
+    output_file_style = "capitalize",
+    pb_file_extensions = [
+        ".pbobjc.h",
+        ".pbobjc.m",
+    ],
+    supports_grpc = True,
 )

--- a/python/BUILD
+++ b/python/BUILD
@@ -4,9 +4,9 @@ load("//protobuf:rules.bzl", "proto_language")
 
 proto_language(
     name = "python",
-    pb_file_extensions = ["_pb2.py"],
-    supports_grpc = True,
     grpc_file_extensions = ["_pb2.py"],
     grpc_plugin = "//external:protoc_gen_grpc_python",
     grpc_plugin_name = "grpc_python",
+    pb_file_extensions = ["_pb2.py"],
+    supports_grpc = True,
 )

--- a/ruby/BUILD
+++ b/ruby/BUILD
@@ -4,9 +4,9 @@ load("//protobuf:rules.bzl", "proto_language")
 
 proto_language(
     name = "ruby",
-    pb_file_extensions = ["_pb.rb"],
-    supports_grpc = True,
     grpc_file_extensions = ["_services_pb.rb"],
     grpc_plugin = "//external:protoc_gen_grpc_ruby",
     grpc_plugin_name = "grpc_ruby",
+    pb_file_extensions = ["_pb.rb"],
+    supports_grpc = True,
 )

--- a/tests/external_proto_library/BUILD
+++ b/tests/external_proto_library/BUILD
@@ -6,27 +6,27 @@ load("//go:rules.bzl", "go_proto_library")
 
 cc_proto_library(
     name = "cc_gapi",
-    protos = ["message.proto"],
+    imports = [
+        "external/com_github_googleapis_googleapis",
+        #'external/com_github_google_protobuf/src',
+    ],
     proto_deps = [
         "@com_github_googleapis_googleapis//:cc_label_proto",
     ],
-    imports = [
-        'external/com_github_googleapis_googleapis',
-        #'external/com_github_google_protobuf/src',
-    ],
+    protos = ["message.proto"],
     verbose = 0,
 )
 
 java_proto_library(
     name = "java_gapi",
-    protos = ["message.proto"],
+    imports = [
+        "external/com_github_googleapis_googleapis",
+        #'external/com_github_google_protobuf/src',
+    ],
     proto_deps = [
         "@com_github_googleapis_googleapis//:java_label_proto",
     ],
-    imports = [
-        'external/com_github_googleapis_googleapis',
-        #'external/com_github_google_protobuf/src',
-    ],
+    protos = ["message.proto"],
     # inputs = [
     #     "@com_github_googleapis_googleapis//:java_label_proto",
     #     "@com_github_google_protobuf//:well_known_protos"
@@ -36,17 +36,17 @@ java_proto_library(
 
 go_proto_library(
     name = "go_gapi",
-    protos = ["message.proto"],
-    proto_deps = [
-        "@com_github_googleapis_googleapis//:go_label_proto",
-    ],
     imports = [
-        'external/com_github_googleapis_googleapis',
+        "external/com_github_googleapis_googleapis",
         #'external/com_github_google_protobuf/src',
     ],
     inputs = [
         #"@com_github_googleapis_googleapis//:go_label_proto",
         #"@com_github_google_protobuf//:well_known_protos"
     ],
+    proto_deps = [
+        "@com_github_googleapis_googleapis//:go_label_proto",
+    ],
+    protos = ["message.proto"],
     verbose = 0,
 )

--- a/tests/with_grpc_false/BUILD
+++ b/tests/with_grpc_false/BUILD
@@ -12,26 +12,26 @@ filegroup(
 
 cc_proto_library(
     name = "cpp",
+    imports = [
+        "external/com_github_google_protobuf/src/",
+    ],
+    inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
     protos = [":protos"],
     verbose = 0,
     with_grpc = False,
-    imports = [
-      "external/com_github_google_protobuf/src/",
-    ],
-    inputs = [
-      "@com_github_google_protobuf//:well_known_protos",
-    ],
 )
 
 java_proto_library(
     name = "java",
+    imports = [
+        "external/com_github_google_protobuf/src/",
+    ],
+    inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
     protos = [":protos"],
     verbose = 0,
     with_grpc = False,
-    imports = [
-      "external/com_github_google_protobuf/src/",
-    ],
-    inputs = [
-      "@com_github_google_protobuf//:well_known_protos",
-    ],
 )


### PR DESCRIPTION
Applied https://github.com/bazelbuild/buildifier to all BUILD files.

Please, feel free to close if that is something not immediately useful. 
Just noticed it being used https://github.com/eclipse/jgit/commit/dd5e500a57fce994331dd9c9a03cb9577998a4a8