### PR TITLE
Include well-known types automatically when possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,47 +32,7 @@ before_install:
   - rm -f install.sh
 
 script:
-  - |
-    bazel \
-      --output_base=$HOME/.cache/bazel \
-      --batch \
-      --host_jvm_args=-Xmx500m \
-      --host_jvm_args=-Xms500m \
-      test \
-      --verbose_failures \
-      --test_output=errors \
-      --test_strategy=standalone \
-      --spawn_strategy=standalone \
-      --genrule_strategy=standalone \
-      --local_resources=400,2,1.0 \
-      --worker_verbose \
-      --strategy=Javac=worker \
-      --strategy=Closure=worker \
-      --deleted_packages=tests/external_proto_library \
-      //examples/helloworld/closure/... \
-      //examples/helloworld/cpp/... \
-      //examples/helloworld/go/... \
-      //examples/helloworld/grpc_gateway/... \
-      //examples/helloworld/java/... \
-      //examples/wkt/... \
-      $FLAGS \
-    && \
-    (cd tests/external_proto_library && bazel \
-      --output_base=$HOME/.cache/bazel \
-      --batch \
-      --host_jvm_args=-Xmx500m \
-      --host_jvm_args=-Xms500m \
-      build \
-      --verbose_failures \
-      --test_output=errors \
-      --test_strategy=standalone \
-      --spawn_strategy=standalone \
-      --genrule_strategy=standalone \
-      --local_resources=400,2,1.0 \
-      --worker_verbose \
-      --strategy=Javac=worker \
-      --strategy=Closure=worker \
-      //:*)
+  - make all
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,83 @@
+BAZEL := "bazel"
+
+STARTUP_FLAGS += --output_base="$HOME/.cache/bazel"
+STARTUP_FLAGS += --host_jvm_args=-Xmx500m
+STARTUP_FLAGS += --host_jvm_args=-Xms500m
+STARTUP_FLAGS += --batch
+#STARTUP_FLAGS := ""
+
+BUILD_FLAGS += --verbose_failures
+BUILD_FLAGS += --spawn_strategy=standalone
+BUILD_FLAGS += --genrule_strategy=standalone
+BUILD_FLAGS += --local_resources=400,2,1.0
+BUILD_FLAGS += --worker_verbose
+BUILD_FLAGS += --strategy=Javac=worker
+BUILD_FLAGS += --strategy=Closure=worker
+BUILD_FLAGS += --experimental_repository_cache="$HOME/.bazel_repository_cache"
+
+TESTFLAGS += $(BUILDFLAGS)
+TEST_FLAGS += --test_output=errors
+TEST_FLAGS += --test_strategy=standalone
+
+BAZEL_BUILD := $(BAZEL) $(STARTFLAGS) $(BAZELFLAGS) build $(BUILDFLAGS)
+BAZEL_TEST := $(BAZEL) $(STARTFLAGS) $(BAZELFLAGS) test $(TEST_FLAGS)
+
+test_not_working_anywhere_targets:
+	$(BAZEL) test \
+	//examples/wkt/cpp:wkt_test \
+	//examples/helloworld/csharp/GreeterClient:GreeterClientTest \
+	//examples/helloworld/csharp/GreeterServer:GreeterServerTest \
+
+
+test_not_working_in_travis_targets:
+	$(BAZEL) build \
+	//examples/helloworld/node:client \
+	//examples/helloworld/node:server \
+
+test_pip_depdendent_targets:
+	$(BAZEL_TEST) \
+	//examples/helloworld/python:test_greeter_server \
+
+all: build test
+
+build: go_package_build external_proto_library_build toffaletti_proto_fail_build
+	$(BAZEL_BUILD) \
+	//examples/extra_args:person_tar \
+	//examples/helloworld/go/client \
+	//examples/helloworld/go/server \
+	//examples/helloworld/grpc_gateway:swagger \
+	//tests/go_import_prefix:x \
+	//tests/go_import_prefix:y \
+	//tests/proto_file_in_subdirectory:baz_cc_proto \
+	//tests/proto_file_in_subdirectory:baz_py_proto \
+	//tests/with_grpc_false:cpp \
+	//tests/with_grpc_false:java \
+	//tests/with_grpc_false:protos \
+
+test:
+	$(BAZEL_TEST) \
+	//examples/helloworld/closure:greeter_test \
+	//examples/helloworld/cpp:test \
+	//examples/helloworld/grpc_gateway:greeter_test \
+	//examples/helloworld/java/org/pubref/rules_protobuf/examples/helloworld/client:netty_test \
+	//examples/helloworld/java/org/pubref/rules_protobuf/examples/helloworld/server:netty_test \
+	//examples/wkt/java:wkt_test \
+	//examples/wkt/go:wkt_test \
+	//tests/proto_file_in_subdirectory:test \
+
+go_package_build:
+	cd tests/go_package && $(BAZEL_BUILD) :main
+
+external_proto_library_build:
+	cd tests/external_proto_library && $(BAZEL_BUILD) :cc_gapi :go_gapi :java_gapi
+
+toffaletti_proto_fail_build:
+	cd tests/toffaletti_proto_fail && $(BAZEL_BUILD) :py_options_proto
+
+
 fmt:
 	buildifier WORKSPACE
 	find bzl/build_file/ -name '*.BUILD' | xargs buildifier
 	find third_party/ -name BUILD | xargs buildifier
 	find examples/ -name BUILD | xargs buildifier
+	find tests/ -name BUILD | xargs buildifier

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,13 +7,12 @@ workspace(name = "org_pubref_rules_protobuf")
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.4.2", # Apr 7, 2017
+    tag = "0.4.2",  # Apr 7, 2017
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 
 go_repositories()
-
 
 # ================================================================
 # closure js_proto_library support requires rules_closure
@@ -29,7 +28,6 @@ load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
 
 closure_repositories()
 
-
 # ================================================================
 # csharp_proto_library support requires rules_dotnet (forked)
 # ================================================================
@@ -44,21 +42,19 @@ load("@io_bazel_rules_dotnet//dotnet:csharp.bzl", "csharp_repositories")
 
 csharp_repositories(use_local_mono = False)
 
-
 # ================================================================
 # node_proto_library support requires rules_node
 # ================================================================
 
 git_repository(
     name = "org_pubref_rules_node",
-    commit = "85b720f3d4299b0a1b9c7771c023352e9182045f",  # Oct 10, 2016
+    commit = "a5bd476899cf526893e090a7ccfb8dcf91965780",  # Apr 15, 2017
     remote = "https://github.com/pubref/rules_node.git",
 )
 
 load("@org_pubref_rules_node//node:rules.bzl", "node_repositories")
 
 node_repositories()
-
 
 # ================================================================
 # Specific Languages Support

--- a/cpp/BUILD
+++ b/cpp/BUILD
@@ -21,5 +21,11 @@ proto_language(
         ".pb.h",
         ".pb.cc",
     ],
+    pb_inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
+    pb_imports = [
+        "external/com_github_google_protobuf/src",
+    ],
     supports_grpc = True,
 )

--- a/cpp/rules.bzl
+++ b/cpp/rules.bzl
@@ -36,25 +36,26 @@ cc_proto_compile = cpp_proto_compile
 
 def cpp_proto_library(
     name,
-    langs = [str(Label("//cpp"))],
-    protos = [],
-    imports = [],
-    inputs = [],
-    proto_deps = [],
-    output_to_workspace = False,
-    protoc = None,
-
-    pb_plugin = None,
-    pb_options = [],
-
+    deps = [],
+    excludes = None,
     grpc_plugin = None,
     grpc_options = [],
-
+    langs = [str(Label("//cpp"))],
+    imports = [],
+    inputs = [],
+    includes = [],
+    pb_plugin = None,
+    pb_options = [],
+    pre_commands = None,
     proto_compile_args = {},
-    with_grpc = True,
+    proto_deps = [],
+    protoc = None,
+    protos = [],
+    root = None,
     srcs = [],
-    deps = [],
+    output_to_workspace = False,
     verbose = 0,
+    with_grpc = True,
     **kwargs):
 
   if with_grpc:
@@ -64,13 +65,17 @@ def cpp_proto_library(
 
   proto_compile_args += {
     "name": name + ".pb",
-    "protos": protos,
+    "pre_commands": pre_commands,
     "deps": [dep + ".pb" for dep in proto_deps],
-    "langs": langs,
-    "imports": imports,
-    "inputs": inputs,
-    "pb_options": pb_options,
+    "excludes": excludes,
     "grpc_options": grpc_options,
+    "imports": imports,
+    "includes": includes,
+    "inputs": inputs,
+    "langs": langs,
+    "pb_options": pb_options,
+    "protos": protos,
+    "root": root,
     "output_to_workspace": output_to_workspace,
     "verbose": verbose,
     "with_grpc": with_grpc,

--- a/examples/extra_args/BUILD
+++ b/examples/extra_args/BUILD
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 # https://github.com/pubref/rules_protobuf/issues/57
 
-load("@org_pubref_rules_protobuf//protobuf:rules.bzl", "proto_compile")
+load("//protobuf:rules.bzl", "proto_compile")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 filegroup(
@@ -18,7 +18,6 @@ proto_compile(
     ],
 
     # For well-known protos, if needed
-    imports = ["external/com_github_google_protobuf/src"],
     inputs = ["@com_github_google_protobuf//:well_known_protos"],
     protos = ["person.proto"],
     verbose = 0,

--- a/examples/helloworld/closure/BUILD
+++ b/examples/helloworld/closure/BUILD
@@ -28,6 +28,7 @@ closure_js_library(
 
 closure_js_test(
     name = "greeter_test",
+    size = "small",
     srcs = ["greeter_test.js"],
     compilation_level = "SIMPLE",
     pedantic = True,

--- a/examples/helloworld/python/BUILD
+++ b/examples/helloworld/python/BUILD
@@ -22,6 +22,7 @@ py_binary(
 
 py_test(
     name = "test_greeter_server",
+    size = "small",
     srcs = ["test_greeter_server.py"],
     deps = [":grpc_server"],
 )

--- a/examples/wkt/cpp/BUILD
+++ b/examples/wkt/cpp/BUILD
@@ -1,0 +1,31 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//cpp:rules.bzl", "cc_proto_library")
+
+cc_proto_library(
+    name = "google_well_known_protos",
+    includes = [
+        "empty.proto",
+    ],
+    protos = ["@com_github_google_protobuf//:well_known_protos"],
+    verbose = 0,
+    with_grpc = False,
+)
+
+# NOT WORKING YET
+#
+# cc_test(
+#     name = "wkt_test",
+#     size = "small",
+#     srcs = ["wkt_test.cc"],
+#     copts = [
+#         "-Iexternal/gtest/include",
+#         "-Iexternal/com_github_google_protobuf/google/protobuf",
+#     ],
+#     deps = [
+#         ":google_well_known_protos",
+#         #"@com_github_google_protobuf//:protobuf",
+#         #"@com_github_google_protobuf//:cc_wkt_protos",
+#         "@gtest//:gtest",
+#     ],
+# )

--- a/examples/wkt/cpp/wkt_test.cc
+++ b/examples/wkt/cpp/wkt_test.cc
@@ -1,0 +1,18 @@
+#include "gtest/gtest.h"
+
+//#include "tests/proto_file_in_subdirectory/foo/bar/baz.pb.h"
+//#include "google_well_known_protos/examples/wkt/cpp/src/google/protobuf/empty.pb.h"
+#include "google/protobuf/empty.pb.h"
+
+TEST(WktTest, CanCreateMessage) {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+  //foo::bar::baz::Qux msg = foo::bar::baz::Qux();
+  google::protobuf::Empty msg = google::protobuf::Empty();
+  //msg.set_verbose(1);
+  EXPECT_EQ(1, 1);
+}
+
+int main(int ac, char* av[]) {
+  testing::InitGoogleTest(&ac, av);
+  return RUN_ALL_TESTS();
+}

--- a/examples/wkt/go/BUILD
+++ b/examples/wkt/go/BUILD
@@ -13,14 +13,14 @@ go_proto_library(
         "google/protobuf/descriptor.proto": "github.com/golang/protobuf/protoc-gen-go/descriptor",
         "google/protobuf/compiler/plugin.proto": "github.com/golang/protobuf/protoc-gen-go/plugin",
     },
-    imports = [
-        "external/com_github_google_protobuf/src",
-    ],
-    inputs = [
-        "@com_github_google_protobuf//:well_known_protos",
-    ],
+    # imports = [
+    #     "external/com_github_google_protobuf/src",
+    # ],
+    # inputs = [
+    #     "@com_github_google_protobuf//:well_known_protos",
+    # ],
     protos = ["wkt.proto"],
-    verbose = 3,
+    verbose = 0,
     deps = [
         "@com_github_golang_protobuf//protoc-gen-go/descriptor:go_default_library",
         "@com_github_golang_protobuf//protoc-gen-go/plugin:go_default_library",

--- a/examples/wkt/java/BUILD
+++ b/examples/wkt/java/BUILD
@@ -1,0 +1,19 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//java:rules.bzl", "java_proto_library")
+
+java_proto_library(
+    name = "google_well_known_protos",
+    protos = ["@com_github_google_protobuf//:well_known_protos"],
+)
+
+java_test(
+    name = "wkt_test",
+    size = "small",
+    srcs = ["WktTest.java"],
+    test_class = "examples.wkt.java.WktTest",
+    deps = [
+        ":google_well_known_protos",
+        "@junit_junit_4//jar",
+    ],
+)

--- a/examples/wkt/java/WktTest.java
+++ b/examples/wkt/java/WktTest.java
@@ -1,0 +1,25 @@
+package examples.wkt.java;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+public class WktTest {
+
+  @Test
+  public void testWkt() {
+    Struct struct = Struct.newBuilder()
+      .putFields("label", Value.newBuilder().setStringValue("foo").build())
+      .putFields("weight", Value.newBuilder().setNumberValue(0.85).build())
+      .build();
+    assertEquals("Well-known struct class should return correct label", "foo", struct.getFields().get("label").getStringValue());
+    assertEquals("Well-known struct class should return correct weight", 0.85, struct.getFields().get("weight").getNumberValue(), 0.00001);
+  }
+
+}

--- a/go/BUILD
+++ b/go/BUILD
@@ -8,4 +8,18 @@ proto_language(
     pb_plugin = "@com_github_golang_protobuf//protoc-gen-go",
     pb_plugin_implements_grpc = True,
     go_prefix = "//:go_prefix",
+    pb_imports = [
+        "external/com_github_google_protobuf/src",
+    ],
+    pb_inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
+)
+
+proto_language(
+    name = "go_without_wkt",
+    pb_file_extensions = [".pb.go"],
+    pb_plugin = "@com_github_golang_protobuf//protoc-gen-go",
+    pb_plugin_implements_grpc = True,
+    go_prefix = "//:go_prefix",
 )

--- a/grpc_gateway/README.md
+++ b/grpc_gateway/README.md
@@ -32,7 +32,6 @@ load("@org_pubref_rules_protobuf//grpc_gateway:rules.bzl", "grpc_gateway_proto_c
 grpc_gateway_proto_compile(
   name = "protos",
   protos = ["message.proto"],
-  with_grpc = True,
 )
 ```
 
@@ -52,7 +51,6 @@ load("@org_pubref_rules_protobuf//grpc_gateway:rules.bzl", "grpc_gateway_proto_l
 grpc_gateway_proto_library(
   name = "protolib",
   protos = ["message.proto"],
-  with_grpc = True,
 )
 ```
 

--- a/grpc_gateway/rules.bzl
+++ b/grpc_gateway/rules.bzl
@@ -47,6 +47,7 @@ def grpc_gateway_proto_library(
     go_proto_deps = [],
     grpc_gateway_deps = GRPC_GATEWAY_DEPS,
     verbose = 0,
+    with_grpc = True,
 
     logtostderr = False,
     alsologtostderr = False,
@@ -75,6 +76,7 @@ def grpc_gateway_proto_library(
     "grpc_options": grpc_options,
     "output_to_workspace": output_to_workspace,
     "verbose": verbose,
+    "with_grpc": with_grpc,
   }
 
   if protoc:

--- a/java/BUILD
+++ b/java/BUILD
@@ -30,6 +30,13 @@ proto_language(
         "@com_google_guava_guava//jar",
         "@com_google_protobuf_protobuf_java//jar",
     ],
+    pb_inputs = [
+        "@com_github_google_protobuf//:well_known_protos",
+    ],
+    pb_imports = [
+        "external/com_github_google_protobuf/src",
+        #"src",
+    ],
     pb_file_extensions = [],
     pb_runtime_deps = [],
     supports_grpc = True,

--- a/tests/external_proto_library/BUILD
+++ b/tests/external_proto_library/BUILD
@@ -13,7 +13,7 @@ cc_proto_library(
         "external/com_github_googleapis_googleapis",
     ],
     proto_deps = [
-        "@com_github_googleapis_googleapis//:cc_label_proto",
+        "@com_github_googleapis_googleapis//:label_cc_proto",
     ],
     protos = ["message.proto"],
     verbose = 0,
@@ -25,7 +25,7 @@ java_proto_library(
         "external/com_github_googleapis_googleapis",
     ],
     proto_deps = [
-        "@com_github_googleapis_googleapis//:java_label_proto",
+        "@com_github_googleapis_googleapis//:label_java_proto",
     ],
     protos = ["message.proto"],
     verbose = 0,
@@ -37,8 +37,33 @@ go_proto_library(
         "external/com_github_googleapis_googleapis",
     ],
     proto_deps = [
-        "@com_github_googleapis_googleapis//:go_label_proto",
+        "@com_github_googleapis_googleapis//:label_go_proto",
     ],
     protos = ["message.proto"],
     verbose = 0,
+)
+
+# Another (probably easier) way of getting the label.proto compiled.
+# Commented out here as both the go_gapi and go_gapi_alternate
+# generate the same message.pb.go (conflicting actions).
+# go_proto_library(
+#     name = "go_gapi_alternate",
+#     imports = [
+#         "external/com_github_googleapis_googleapis",
+#     ],
+#     proto_deps = [
+#         ":label_go_proto",
+#     ],
+#     protos = ["message.proto"],
+#     verbose = 0,
+# )
+
+# This is an example of cherry picking  go protos in external workspaces as well.  In this case it has the
+# go_package option.
+go_proto_library(
+    name = "label_go_proto",
+    go_package = "google.golang.org/genproto/googleapis/api/label",
+    protos = [
+        "@com_github_googleapis_googleapis//:google/api/label.proto",
+    ],
 )

--- a/tests/go_import_prefix/BUILD
+++ b/tests/go_import_prefix/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//go:rules.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "x",
+    protos = [
+        "x.proto",
+    ],
+    verbose = 0,
+)
+
+go_proto_library(
+    name = "y",
+    proto_deps = [
+        ":x",
+    ],
+    protos = [
+        "y.proto",
+    ],
+    verbose = 0,
+)

--- a/tests/go_import_prefix/x.proto
+++ b/tests/go_import_prefix/x.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package A;
+
+message X {
+  string name = 1;
+}

--- a/tests/go_import_prefix/y.proto
+++ b/tests/go_import_prefix/y.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package A;
+
+import "tests/go_import_prefix/x.proto";
+
+message Y {
+  string name = 1;
+  X x = 2;
+}

--- a/tests/go_package/BUILD
+++ b/tests/go_package/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix", "go_binary")
+load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library", "PB_COMPILE_DEPS")
+
+go_prefix("github.com/pubref/rules_protobuf/tests/go_package")
+
+go_proto_library(
+    name = "file_in_package_root",
+    go_package = "pubref.org/test/app",
+    protos = ["file_in_package_root.proto"],
+    verbose = 0,
+)
+
+go_binary(
+    name = "main",
+    srcs = ["main.go"],
+    deps = [
+        "//proto:config_go_proto",
+        ":file_in_package_root",
+    ] + PB_COMPILE_DEPS,
+)

--- a/tests/go_package/WORKSPACE
+++ b/tests/go_package/WORKSPACE
@@ -42,7 +42,7 @@ load("@org_pubref_rules_protobuf//java:rules.bzl", "java_proto_library")
 load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
 
 cc_proto_library(
-    name = "label_cc_proto",
+    name = "cc_label_proto",
     protos = [
         "google/api/label.proto",
     ],
@@ -50,7 +50,7 @@ cc_proto_library(
 )
 
 java_proto_library(
-    name = "label_java_proto",
+    name = "java_label_proto",
     protos = [
         "google/api/label.proto",
     ],
@@ -58,7 +58,7 @@ java_proto_library(
 )
 
 go_proto_library(
-    name = "label_go_proto",
+    name = "go_label_proto",
     protos = [
         "google/api/label.proto",
     ],

--- a/tests/go_package/app.proto
+++ b/tests/go_package/app.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+option go_package = "pubref.org/test/app";
+
+message App {
+  string name = 1;
+}
+

--- a/tests/go_package/file_in_package_root.proto
+++ b/tests/go_package/file_in_package_root.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+option go_package = "pubref.org/test/app";
+
+message App {
+  string name = 1;
+}
+

--- a/tests/go_package/main.go
+++ b/tests/go_package/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"log"
+
+	// The expected import for a proto file having the go_package
+	// option 'pubref.org/test/app'.  However, although protoc
+	// generates the file in this location, rules_go sets up the
+	// compilation directory for the message_proto target using
+	// the go_prefix from the workspace //:BUILD file (thus, the
+	// go_package option is washed away).
+	//
+	// rules_protobuf copies the location of the actual generated
+	// file output to the one expected by rules_go.  Thus, the
+	// actual import path must match the same semantics of other
+	// go proto imports, (GO_PREFIX/LABEL_PACKAGE/LABEL_NAME).
+	//
+	// This probably will break with protos that have complex
+	// import dependencies that require the go_package option.
+
+	// EXPECTED
+	//pb "proto/pubref.org/test/app/config_proto"
+
+	// ACTUAL
+	proto "github.com/pubref/rules_protobuf/tests/go_package/proto/config_go_proto"
+	//     |                                                 |     |
+	//     ^ go_prefix                                       |     |
+	//                                                       ^ label.package
+	//                                                             |
+	//                                                             ^ label.name
+
+	// ACTUAL
+	root "github.com/pubref/rules_protobuf/tests/go_package/file_in_package_root"
+	//   |                                                 ||
+	//   ^ go_prefix                                       ||
+	//                                                     ^ label.package
+	//                                                      |
+	//                                                      ^ label.name
+
+)
+
+func main() {
+	app := &root.App{Name: "MyApp"}
+	config := &proto.Config{Label: "Hello"}
+	log.Printf("App '%s' has config label: %s", app.Name, config.Label)
+}

--- a/tests/go_package/parent_repository.bzl
+++ b/tests/go_package/parent_repository.bzl
@@ -1,0 +1,35 @@
+#
+# Repository rule implementation that avoids the need for a
+# `local_repository` rule referencing the parent WORKSPACE.
+#
+
+def _parent_repository_impl(rtx):
+    # Get the absolute path if the 'source' label and convert to a string
+    path = "%s" % rtx.path(rtx.attr._source)
+
+    # Convert /Users/pcj/github/rules_protobuf/.../parent_repository.bzl
+    # to      /Users/pcj/github/rules_protobuf
+    parts = path.split('/')
+    parent_dir = parts[0:-3]
+
+    # Symlink the list of dirs to expose
+    for dirname in rtx.attr.exposed_dirs:
+        rtx.symlink('/%s' % "/".join(parent_dir + [dirname]), dirname)
+
+
+parent_repository = repository_rule(
+    implementation = _parent_repository_impl,
+    attrs = {
+        # We need to discover the absolute path of any file in the
+        # current directory to symlink the parent workspace maven dir.
+        "_source": attr.label(
+            default = Label("//:parent_repository.bzl")
+        ),
+        "exposed_dirs": attr.string_list(
+            default = [
+                "protobuf",
+                "go",
+            ],
+        )
+    },
+)

--- a/tests/go_package/proto/BUILD
+++ b/tests/go_package/proto/BUILD
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "config_go_proto",
+    go_package = "pubref.org/test/app",
+    protos = ["config.proto"],
+    verbose = 0,
+)

--- a/tests/go_package/proto/config.proto
+++ b/tests/go_package/proto/config.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+option go_package = "pubref.org/test/app";
+
+message Config {
+  string label = 1;
+}
+

--- a/tests/go_package/proto/message.proto
+++ b/tests/go_package/proto/message.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+option go_package = "pubref.org/test/message";
+
+message Config {
+  string label = 1;
+}
+

--- a/tests/proto_file_in_subdirectory/BUILD
+++ b/tests/proto_file_in_subdirectory/BUILD
@@ -1,4 +1,5 @@
 load("//cpp:rules.bzl", "cc_proto_library")
+load("//python:rules.bzl", "py_proto_compile")
 
 cc_test(
     name = "test",
@@ -6,15 +7,24 @@ cc_test(
     srcs = ["qux_test.cc"],
     copts = ["-Iexternal/gtest/include"],
     deps = [
-        ":protolib",
+        ":baz_cc_proto",
         "@gtest//:gtest",
     ],
 )
 
 cc_proto_library(
-    name = "protolib",
+    name = "baz_cc_proto",
     protos = [
         "foo/bar/baz.proto",
+    ],
+    verbose = 0,
+)
+
+py_proto_compile(
+    name = "baz_py_proto",
+    protos = [
+        "foo/bar/baz.proto",
+        "foo/bar/options.proto",
     ],
     verbose = 0,
 )

--- a/tests/proto_file_in_subdirectory/foo/bar/options.proto
+++ b/tests/proto_file_in_subdirectory/foo/bar/options.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Foo {
+}
+

--- a/tests/toffaletti_proto_fail/BUILD
+++ b/tests/toffaletti_proto_fail/BUILD
@@ -1,0 +1,9 @@
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_compile")
+
+py_proto_compile(
+    name = "py_options_proto",
+    protos = ["models/options.proto"],
+    verbose = 0,
+    visibility = ["//visibility:public"],
+    with_grpc = False,
+)

--- a/tests/toffaletti_proto_fail/WORKSPACE
+++ b/tests/toffaletti_proto_fail/WORKSPACE
@@ -1,0 +1,14 @@
+load("//:parent_repository.bzl", "parent_repository")
+
+parent_repository(
+    name = "org_pubref_rules_protobuf",
+    exposed_dirs = [
+        "BUILD",
+        "cpp",
+        "protobuf",
+        "python",
+    ]
+)
+
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_repositories")
+py_proto_repositories()

--- a/tests/toffaletti_proto_fail/models/options.proto
+++ b/tests/toffaletti_proto_fail/models/options.proto
@@ -1,0 +1,4 @@
+syntax="proto3";
+
+message Foo {
+}

--- a/tests/toffaletti_proto_fail/parent_repository.bzl
+++ b/tests/toffaletti_proto_fail/parent_repository.bzl
@@ -1,0 +1,35 @@
+#
+# Repository rule implementation that avoids the need for a
+# `local_repository` rule referencing the parent WORKSPACE.
+#
+
+def _parent_repository_impl(rtx):
+    # Get the absolute path if the 'source' label and convert to a string
+    path = "%s" % rtx.path(rtx.attr._source)
+
+    # Convert /Users/pcj/github/rules_protobuf/.../parent_repository.bzl
+    # to      /Users/pcj/github/rules_protobuf
+    parts = path.split('/')
+    parent_dir = parts[0:-3]
+
+    # Symlink the list of dirs to expose
+    for dirname in rtx.attr.exposed_dirs:
+        rtx.symlink('/%s' % "/".join(parent_dir + [dirname]), dirname)
+
+
+parent_repository = repository_rule(
+    implementation = _parent_repository_impl,
+    attrs = {
+        # We need to discover the absolute path of any file in the
+        # current directory to symlink the parent workspace maven dir.
+        "_source": attr.label(
+            default = Label("//:parent_repository.bzl")
+        ),
+        "exposed_dirs": attr.string_list(
+            default = [
+                "protobuf",
+                "python",
+            ],
+        )
+    },
+)

--- a/tests/with_grpc_false/BUILD
+++ b/tests/with_grpc_false/BUILD
@@ -2,8 +2,8 @@ package(default_visibility = ["//visibility:public"])
 
 # See https://github.com/pubref/rules_protobuf/issues/48
 
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cc_proto_library")
-load("@org_pubref_rules_protobuf//java:rules.bzl", "java_proto_library")
+load("//cpp:rules.bzl", "cc_proto_library")
+load("//java:rules.bzl", "java_proto_library")
 
 filegroup(
     name = "protos",


### PR DESCRIPTION
* Adds @com_github_google_protobuf//:well_known_protos to the {c++,go,java} proto_language default inputs.
* Adds external/com_github_google_protobuf/src  to the {c++,go,java} proto_language default imports.
* Adds tests for wkt for go, java, c++ (c++ not actually working yet, heh).
* Rewrite of the build_output_files codepath to accomodate go_package option and improved handling
  of external workspaces.
* Adds the pre_command and post_command proto_compile options (used internally).
* Adds tests for go_package option.
* Sorted proto_compile attrs, added brief descriptive comments.
* Run buildifier.
* Moved .travis script logic to Makefile.