### PR TITLE
Automatically generate a protoc friendly dependency tree from the proto_deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,24 @@ script:
       //examples/wkt/... \
       $FLAGS \
     && \
+    (bazel \
+      --output_base=$HOME/.cache/bazel \
+      --batch \
+      --host_jvm_args=-Xmx500m \
+      --host_jvm_args=-Xms500m \
+      build \
+      --verbose_failures \
+      --test_output=errors \
+      --test_strategy=standalone \
+      --spawn_strategy=standalone \
+      --genrule_strategy=standalone \
+      --local_resources=400,2,1.0 \
+      --worker_verbose \
+      --strategy=Javac=worker \
+      --strategy=Closure=worker \
+      --deleted_packages=tests/external_proto_library \
+      //tests/...) \
+    && \
     (cd tests/external_proto_library && bazel \
       --output_base=$HOME/.cache/bazel \
       --batch \

--- a/tests/transitive_dependencies/bottom/BUILD
+++ b/tests/transitive_dependencies/bottom/BUILD
@@ -1,0 +1,27 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//java:rules.bzl", "java_proto_library")
+
+alias(
+  name = 'bottom',
+  actual = ':bottom_proto_java',
+)
+
+java_proto_library(
+    name = "google_well_known_protos",
+    protos = ["@com_github_google_protobuf//:well_known_protos"],
+    imports = ["src"],
+)
+
+java_proto_library(
+    name = "bottom_proto_java",
+    protos = [":srcs"],
+    proto_deps = [
+      ":google_well_known_protos",
+    ],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = ["examples/proto/bottom.proto"],
+)

--- a/tests/transitive_dependencies/bottom/examples/proto/bottom.proto
+++ b/tests/transitive_dependencies/bottom/examples/proto/bottom.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+option java_package = "examples.proto";
+option java_outer_classname = "BottomProto";
+
+package bottom;
+
+import "google/protobuf/descriptor.proto";
+
+message BottomMessage {
+  bool verbose = 1;
+  google.protobuf.FileDescriptorProto file = 2;
+}
+
+extend google.protobuf.MessageOptions {
+  string my_option = 10001;
+}

--- a/tests/transitive_dependencies/bottom/examples/proto/error.proto
+++ b/tests/transitive_dependencies/bottom/examples/proto/error.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "examples.proto";
+option java_outer_classname = "ErrorProto";
+
+package error;
+
+# This proto has an intentional compilation error and should not be included
+# in protoc builds if the proto path imports are working correctly
+message DoesNotCompile {
+  string name =;
+}

--- a/tests/transitive_dependencies/middle/BUILD
+++ b/tests/transitive_dependencies/middle/BUILD
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//java:rules.bzl", "java_proto_library")
+
+alias(
+  name = 'middle',
+  actual = ':middle_proto_java',
+)
+
+java_proto_library(
+    name = "middle_proto_java",
+    protos = [":srcs"],
+    proto_deps = [
+      "//tests/transitive_dependencies/bottom:bottom_proto_java",
+    ],
+)
+
+filegroup(
+  name = "srcs",
+  srcs = glob(["**/*.proto"]),
+)

--- a/tests/transitive_dependencies/middle/examples/proto/middle.proto
+++ b/tests/transitive_dependencies/middle/examples/proto/middle.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+option java_package = "examples.proto";
+option java_outer_classname = "MiddleProto";
+
+package middle;
+
+import "examples/proto/bottom.proto";
+
+message MiddleMessage {
+  bool verbose = 1;
+}
+
+service Middle {
+  rpc InTheMiddle (bottom.BottomMessage) returns (bottom.BottomMessage) {}
+}

--- a/tests/transitive_dependencies/top/BUILD
+++ b/tests/transitive_dependencies/top/BUILD
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//java:rules.bzl", "java_proto_library")
+
+alias(
+  name = 'top',
+  actual = ':top_proto_java',
+)
+
+java_proto_library(
+    name = "top_proto_java",
+    protos = [":srcs"],
+    proto_deps = [
+      "//tests/transitive_dependencies/middle:middle_proto_java",
+    ],
+)
+
+filegroup(
+  name = "srcs",
+  srcs = glob(["**/*.proto"]),
+)

--- a/tests/transitive_dependencies/top/examples/proto/top.proto
+++ b/tests/transitive_dependencies/top/examples/proto/top.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+option java_package = "examples.proto";
+option java_outer_classname = "TopProto";
+
+package top;
+
+import "examples/proto/middle.proto";
+
+message TopMessage {
+  bool verbose = 1;
+}
+
+service Top {
+  rpc OnTop (middle.MiddleMessage) returns (middle.MiddleMessage) {}
+}

--- a/tests/with_grpc_false/BUILD
+++ b/tests/with_grpc_false/BUILD
@@ -2,8 +2,8 @@ package(default_visibility = ["//visibility:public"])
 
 # See https://github.com/pubref/rules_protobuf/issues/48
 
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cc_proto_library")
-load("@org_pubref_rules_protobuf//java:rules.bzl", "java_proto_library")
+load("//cpp:rules.bzl", "cc_proto_library")
+load("//java:rules.bzl", "java_proto_library")
 
 filegroup(
     name = "protos",


### PR DESCRIPTION
This PR addresses https://github.com/pubref/rules_protobuf/issues/84, https://github.com/pubref/rules_protobuf/issues/59 and https://github.com/pubref/rules_protobuf/issues/22.

The main problem it fixes is having to supply all of the paths of your transitive dependencies in your imports.  For example before this change the `java_proto_library` of `tests/transitive_dependencies/top/BUILD` looked like this:
```
java_proto_library(
  name = "top_proto_java",
  protos = [":srcs"],
  proto_deps = [
    "//tests/transitive_dependencies/middle:middle_proto_java",
  ],
  imports = [
    "tests/transitive_dependencies/bottom",
    "tests/transitive_dependencies/middle",
    "external/com_github_google_protobuf/src"
  ],
)
```
now the `proto_compile` rule will create the transitive dependency tree from the proto_deps.
```
java_proto_library(
  name = "top_proto_java",
  protos = [":srcs"],
  proto_deps = [
    "//tests/transitive_dependencies/middle:middle_proto_java",
  ]
)
```

It does this by creating a directory of symlinks to the input proto files of the transitive dependencies and providing this as a `--proto_path` to protoc.

These changes are working for me so far but I am relatively new to Bazel so I'm not sure if I'm following all of the correct conventions for coding style and intermediate scripts etc.  I have also primarily tested these changes with `java_proto_library`.  
