### PR TITLE
Update grpc_gateway docs

### DIFF
--- a/grpc_gateway/README.md
+++ b/grpc_gateway/README.md
@@ -32,7 +32,6 @@ load("@org_pubref_rules_protobuf//grpc_gateway:rules.bzl", "grpc_gateway_proto_c
 grpc_gateway_proto_compile(
   name = "protos",
   protos = ["message.proto"],
-  with_grpc = True,
 )
 ```
 
@@ -51,8 +50,7 @@ load("@org_pubref_rules_protobuf//grpc_gateway:rules.bzl", "grpc_gateway_proto_l
 
 grpc_gateway_proto_library(
   name = "protolib",
-  protos = ["message.proto"],
-  with_grpc = True,
+  protos = ["message.proto"]
 )
 ```
 

--- a/grpc_gateway/README.md
+++ b/grpc_gateway/README.md
@@ -50,7 +50,7 @@ load("@org_pubref_rules_protobuf//grpc_gateway:rules.bzl", "grpc_gateway_proto_l
 
 grpc_gateway_proto_library(
   name = "protolib",
-  protos = ["message.proto"]
+  protos = ["message.proto"],
 )
 ```
 


### PR DESCRIPTION
`with_grpc` in these examples is likely the cause of issues #65 and #86 since this property is not a valid property for these rules.