### PR TITLE
Advance grpc_gateway support to 1.2

### DIFF
--- a/grpc_gateway/BUILD
+++ b/grpc_gateway/BUILD
@@ -7,16 +7,17 @@ proto_language(
     grpc_file_extensions = [".pb.gw.go"],
     grpc_imports = [
         "external/com_github_google_protobuf/src/",
-        "external/com_github_grpc_ecosystem_grpc_gateway/third_party/googleapis/",
+        "external/com_github_grpc_ecosystem_grpc_gateway_googleapis/",
     ],
     grpc_inputs = [
-        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
         "@com_github_google_protobuf//:well_known_protos",
+        "@com_github_grpc_ecosystem_grpc_gateway_googleapis//:annotations_protos",
+        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
     ],
     grpc_plugin = "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway",
     grpc_plugin_name = "grpc-gateway",
     importmap = {
-        "google/api/annotations.proto": "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api",
+        "google/api/annotations.proto": "google.golang.org/genproto/googleapis/api/annotations",
     },
     go_prefix = "//:go_prefix",
     supports_grpc = True,
@@ -26,16 +27,17 @@ proto_language(
 proto_language(
     name = "pb_gateway",
     importmap = {
-        "google/api/annotations.proto": "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api",
+        "google/api/annotations.proto": "google.golang.org/genproto/googleapis/api/annotations",
     },
     pb_file_extensions = [".pb.go"],
     pb_imports = [
         "external/com_github_google_protobuf/src/",
-        "external/com_github_grpc_ecosystem_grpc_gateway/third_party/googleapis/",
+        "external/com_github_grpc_ecosystem_grpc_gateway_googleapis/",
     ],
     pb_inputs = [
-        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
         "@com_github_google_protobuf//:well_known_protos",
+        "@com_github_grpc_ecosystem_grpc_gateway_googleapis//:annotations_protos",
+        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
     ],
     pb_plugin = "@com_github_golang_protobuf//protoc-gen-go",
     pb_plugin_implements_grpc = True,
@@ -46,16 +48,17 @@ proto_language(
 proto_language(
     name = "swagger",
     importmap = {
-        "google/api/annotations.proto": "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api",
+        "google/api/annotations.proto": "google.golang.org/genproto/googleapis/api/annotations",
     },
     pb_file_extensions = [".swagger.json"],
     pb_imports = [
         "external/com_github_google_protobuf/src/",
-        "external/com_github_grpc_ecosystem_grpc_gateway/third_party/googleapis/",
+        "external/com_github_grpc_ecosystem_grpc_gateway_googleapis/",
     ],
     pb_inputs = [
-        "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library_protos",
         "@com_github_google_protobuf//:well_known_protos",
+        "@com_github_grpc_ecosystem_grpc_gateway_googleapis//:annotations_protos",
+        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
     ],
     pb_plugin = "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-swagger",
     go_prefix = "//:go_prefix",

--- a/grpc_gateway/deps.bzl
+++ b/grpc_gateway/deps.bzl
@@ -1,8 +1,37 @@
+GOOGLEAPIS_BUILD_FILE = """
+filegroup(
+  name = "annotations_protos",
+  srcs = [
+    "google/api/annotations.proto",
+    "google/api/http.proto",
+  ],
+  visibility = ["//visibility:public"]
+)
+"""
+
 DEPS = {
+
     "com_github_grpc_ecosystem_grpc_gateway": {
         "rule": "new_go_repository",
         "importpath": "github.com/grpc-ecosystem/grpc-gateway",
-        "commit": "686368427ddb9a51628d63db6c74fbc96a206e1f", # Jan 24, 2017
+        "commit": "2ad234c172af14e85f3be9546f6c64c768d4eccd", # Apr 4, 2017
+        #"commit": "597c8c358cb7475bc9fc495af32f94065aa6b6e1", # Apr 24, 2017
+        # TODO: figure out why newest commit fails with `context.go:99: undefined: metadata.NewOutgoingContext`
     },
+
+    "com_github_grpc_ecosystem_grpc_gateway_googleapis": {
+        "rule": "new_http_archive",
+        "url": "http://github.com/grpc-ecosystem/grpc-gateway/archive/597c8c358cb7475bc9fc495af32f94065aa6b6e1.zip",
+        "strip_prefix": "grpc-gateway-597c8c358cb7475bc9fc495af32f94065aa6b6e1/third_party/googleapis", # Apr 24, 2017
+        "sha256": "36d2f6f44271bc397c3ded20a35c3b78024e873615caf417fdafde08500ca78d",
+        "build_file_content": GOOGLEAPIS_BUILD_FILE,
+    },
+
+    "org_golang_google_genproto": {
+        "rule": "new_go_repository",
+        "importpath": "google.golang.org/genproto",
+        "commit": "411e09b969b1170a9f0c467558eb4c4c110d9c77", # Apr 4, 2017
+    },
+
 
 }

--- a/grpc_gateway/rules.bzl
+++ b/grpc_gateway/rules.bzl
@@ -7,6 +7,8 @@ def grpc_gateway_proto_repositories(
     lang_deps = DEPS,
     lang_requires = [
       "com_github_grpc_ecosystem_grpc_gateway",
+      "com_github_grpc_ecosystem_grpc_gateway_googleapis",
+      "org_golang_google_genproto",
     ], **kwargs):
 
   go_proto_repositories(lang_deps = lang_deps,
@@ -16,7 +18,7 @@ def grpc_gateway_proto_repositories(
 GRPC_GATEWAY_DEPS = [
   "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
   "@com_github_grpc_ecosystem_grpc_gateway//utilities:go_default_library",
-  "@com_github_grpc_ecosystem_grpc_gateway//third_party/googleapis/google/api:go_default_library",
+  "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
   "@org_golang_google_grpc//codes:go_default_library",
   "@org_golang_google_grpc//grpclog:go_default_library",
   "@org_golang_google_grpc//:go_default_library",


### PR DESCRIPTION
* Adds new dependency on org_golang_go_genproto for pre-compiled google/api protos.
* Adds new dependency on a stripped copy of grpc_gateway for the actual google/api source protos.

Fixes #77