### PR TITLE
Use pascal file style for objc protos

### DIFF
--- a/objc/BUILD
+++ b/objc/BUILD
@@ -10,7 +10,7 @@ proto_language(
     ],
     grpc_plugin = "//external:protoc_gen_grpc_objc",
     grpc_plugin_name = "grpc_objc",
-    output_file_style = "capitalize",
+    output_file_style = "pascal",
     pb_file_extensions = [
         ".pbobjc.h",
         ".pbobjc.m",


### PR DESCRIPTION
Obj-C protocol buffers with underscores in the filename cannot be build because bazel looks for the wrong output file. Setting the output_file_style to "pascal" fixes this.

For example: the proto some_thing.proto is compiled to SomeThing.pbobjc.h which is what bazel expects. I tested it with bazel v0.5.1.