### PR TITLE
Update to rules_go 0.5.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,7 +7,7 @@ workspace(name = "org_pubref_rules_protobuf")
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.4.2", # Apr 7, 2017
+    tag = "0.5.2", # July 17, 2017
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")

--- a/go/deps.bzl
+++ b/go/deps.bzl
@@ -5,25 +5,25 @@
 DEPS = {
 
     "org_golang_x_net": {
-        "rule": "new_go_repository",
+        "rule": "go_repository",
         "importpath": "golang.org/x/net",
         "commit": "2a35e686583654a1b89ca79c4ac78cb3d6529ca3",
     },
 
     "com_github_golang_glog": {
-        "rule": "new_go_repository",
+        "rule": "go_repository",
         "importpath": "github.com/golang/glog",
         "commit": "23def4e6c14b4da8ac2ed8007337bc5eb5007998", # Jan 25, 2016
     },
 
     "com_github_golang_protobuf": {
-        "rule": "new_go_repository",
+        "rule": "go_repository",
         "importpath": "github.com/golang/protobuf",
         "commit": "8ee79997227bf9b34611aee7946ae64735e6fd93", # ~ Nov 16, 2016
     },
 
     "org_golang_google_grpc": {
-        "rule": "new_go_repository",
+        "rule": "go_repository",
         "importpath": "google.golang.org/grpc",
         "tag": "v1.2.1",
     },

--- a/go/rules.bzl
+++ b/go/rules.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "new_go_repository")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_repository")
 load("//protobuf:rules.bzl", "proto_compile", "proto_repositories")
 load("//go:deps.bzl", "DEPS")
 
@@ -18,8 +18,8 @@ def go_proto_repositories(
   # Load remaining (special) deps
   for dep in rem:
     rule = dep.pop("rule")
-    if "new_go_repository" == rule:
-      new_go_repository(**dep)
+    if "go_repository" == rule:
+      go_repository(**dep)
     else:
       fail("Unknown loading rule %s for %s" % (rule, dep))
 

--- a/gogo/deps.bzl
+++ b/gogo/deps.bzl
@@ -1,7 +1,7 @@
 DEPS = {
 
   "com_github_gogo_protobuf": {
-      "rule": "new_go_repository",
+      "rule": "go_repository",
       "importpath": "github.com/gogo/protobuf",
       "commit": "100ba4e885062801d56799d78530b73b178a78f3", # Mar 7, 2017
   },

--- a/grpc_gateway/deps.bzl
+++ b/grpc_gateway/deps.bzl
@@ -12,7 +12,7 @@ filegroup(
 DEPS = {
 
     "com_github_grpc_ecosystem_grpc_gateway": {
-        "rule": "new_go_repository",
+        "rule": "go_repository",
         "importpath": "github.com/grpc-ecosystem/grpc-gateway",
         "commit": "2ad234c172af14e85f3be9546f6c64c768d4eccd", # Apr 4, 2017
         #"commit": "597c8c358cb7475bc9fc495af32f94065aa6b6e1", # Apr 24, 2017
@@ -28,7 +28,7 @@ DEPS = {
     },
 
     "org_golang_google_genproto": {
-        "rule": "new_go_repository",
+        "rule": "go_repository",
         "importpath": "google.golang.org/genproto",
         "commit": "411e09b969b1170a9f0c467558eb4c4c110d9c77", # Apr 4, 2017
     },

--- a/tests/external_proto_library/WORKSPACE
+++ b/tests/external_proto_library/WORKSPACE
@@ -3,10 +3,10 @@ load("//:parent_repository.bzl", "parent_repository")
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.4.2", # Apr 7, 2017
+    tag = "0.5.2", # July 17, 2017
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
+load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "go_repository")
 
 go_repositories()
 


### PR DESCRIPTION
For your consideration:

This PR moves to [rules_go v0.5.2](https://github.com/bazelbuild/rules_go/releases/tag/0.5.2). As part of that transition, it switches from the deprecated `new_go_repository` to the now preferred `go_repository`.