### PR TITLE
Update dependency on github/golang/protobuf to latest.

### DIFF
--- a/go/deps.bzl
+++ b/go/deps.bzl
@@ -19,7 +19,7 @@ DEPS = {
     "com_github_golang_protobuf": {
         "rule": "new_go_repository",
         "importpath": "github.com/golang/protobuf",
-        "commit": "8ee79997227bf9b34611aee7946ae64735e6fd93", # ~ Nov 16, 2016
+        "commit": "748d386b5c1ea99658fd69fe9f03991ce86a90c1", # ~ Jul 26, 2017
     },
 
     "org_golang_google_grpc": {


### PR DESCRIPTION
For your convenience, the relevant commit list is
https://github.com/golang/protobuf/commits/master

I would like this since it would make it possible for me to link
against a modern timestamp.proto.

I changed the hash to the most recent change, but the change
that is most important to me is
github.com/golang/protobuf/commit/157d9c53be5810dd5a0fac4a467f7d5f400042ea
> regenerate pb.go files with protobuf 3.3.0

It would also be nice to have
github.com/golang/protobuf/commit/5a0f697c9ed9d68fef0116532c6e05cfeae00e55
> Deserialize JSON NaN, Infinity and -Infinity to corresponding Go values

----

The problem I'm trying to address is

```sh
ERROR: /ELIDED/BUILD:57:1: null failed: Process exited with status 1 [sandboxed].
bazel-out/darwin_x86_64-fastbuild/genfiles/api/common.pb.go:79: (*timestamp.Timestamp)(m).GetSeconds undefined (type *timestamp.Timestamp has no field or method GetSeconds)
bazel-out/darwin_x86_64-fastbuild/genfiles/api/common.pb.go:80: (*timestamp.Timestamp)(m).GetNanos undefined (type *timestamp.Timestamp has no field or method GetNanos)
2017/08/01 17:21:35 error running compiler: exit status 1
Use --strategy=GoCompile=standalone to disable sandboxing for the failing actions.
```

which is prompted by a proto3 file that does

```proto
import public "google/protobuf/timestamp.proto";
```

and is built thus

```py
IMPORTS = [
    "external/com_github_google_protobuf/src",
    "external/com_github_googleapis_googleapis",
]

# Proto files we depend upon.
INPUTS = [
    "@com_github_google_protobuf//:well_known_protos",
    "@com_github_googleapis_googleapis//:well_known_protos",
]

...

go_proto_library(
    name = "go",
    imports = IMPORTS,
    inputs = INPUTS,
    proto_compile_args = {
        "visibility": VISIBILITY,
    },
    deps = (
        [
            "@com_github_golang_protobuf//ptypes:go_default_library",
            "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
        ]
        + GRPC_COMPILE_DEPS
    ),
    protos = PROTOS,
    visibility = VISIBILITY,
    with_grpc = WITH_GRPC,
    verbose = 1,
)
```