### PR TITLE
Add support for using generated protos w/o output_to_workspace

### DIFF
--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -331,8 +331,12 @@ def _build_protobuf_out(run, builder):
   """Build the --{lang}_out option"""
   lang = run.lang
   name = lang.pb_plugin_name or lang.name
-  outdir = builder.get(lang.name + "_outdir", run.outdir)
   options = builder.get(lang.name + "_pb_options", [])
+
+  if run.data.protos[0].path.startswith(run.ctx.var["GENDIR"]):
+    outdir = "."
+  else:
+    outdir = builder.get(lang.name + "_outdir", run.outdir)
 
   _build_plugin_out(name, outdir, options, builder)
 
@@ -341,7 +345,12 @@ def _build_grpc_out(run, builder):
   """Build the --{lang}_out grpc option"""
   lang = run.lang
   name = lang.grpc_plugin_name or "grpc-" + lang.name
-  outdir = builder.get(lang.name + "_outdir", run.outdir)
+
+  if run.data.protos[0].path.startswith(run.ctx.var["GENDIR"]):
+    outdir = "."
+  else:
+    outdir = builder.get(lang.name + "_outdir", run.outdir)
+
   options = builder.get(lang.name + "_grpc_options", [])
 
   _build_plugin_out(name, outdir, options, builder)

--- a/tests/generated_proto_file/BUILD
+++ b/tests/generated_proto_file/BUILD
@@ -1,0 +1,34 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//cpp:rules.bzl", "cpp_proto_library")
+load("//go:rules.bzl", "go_proto_library")
+
+genrule(
+     name = "copy_file",
+     srcs = ["simple.proto"],
+     outs = ["copy.proto"],
+     cmd = "cat $(location simple.proto) > $@",
+     message = "copy",
+)
+
+cpp_proto_library(
+   name = "default_library",
+   protos = ["simple.proto"],
+)
+
+cpp_proto_library(
+   name = "copy_library",
+   protos = ["copy.proto"],   
+   with_grpc = True,
+)
+
+go_proto_library(
+   name = "go_default_library",
+   protos = ["simple.proto"],
+)
+
+go_proto_library(
+   name = "go_copy_library",
+   protos = ["copy.proto"],
+   with_grpc = True,
+)

--- a/tests/generated_proto_file/simple.proto
+++ b/tests/generated_proto_file/simple.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package simple;
+
+message Test {
+    string value = 1;
+}


### PR DESCRIPTION
This PR is an attempt to deal with issues related to generating *_proto_libraries from proto files that were also generated as part of a bazel build.

When calculating protobuf_out and grpc_out, this PR adds logic that compares the path of the first proto being compiled to the bazel GENDIR. If the path startswith the GENDIR, this PR sets the outdir to ".".

An example "test" is also included to exercise this logic (for cpp and go proto libs).

Fixes: #116