### PR TITLE
Update rules_python to avoid builtin conflict.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -73,10 +73,10 @@ node_repositories()
 
 github_archive(
     name = "io_bazel_rules_python",
-    commit = "7f4cc9244dac7637d514e4f86364507681dda37e",
+    commit = "d6fbb0fb2a5c8e318dd4de5104dc41358cefaa90",
     org = "bazelbuild",
     repo = "rules_python",
-    sha256 = "ad11daa2e991309eb672b9f18cdc650893e30610fbcccac539bd9c7ca5a5f7ca",
+    sha256 = "43dceb1be46d1c6c1a08d510931982664f1115a399a3bce1a419e63143e5b6c1",
 )
 
 load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip_import")

--- a/examples/helloworld/python/BUILD
+++ b/examples/helloworld/python/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@pip_grpcio//:requirements.bzl", "package")
+load("@pip_grpcio//:requirements.bzl", "requirement")
 
 py_binary(
     name = "greeter_client",
@@ -9,7 +9,7 @@ py_binary(
     ],
     deps = [
         "//examples/helloworld/proto:py",
-        package("grpcio"),
+        requirement("grpcio"),
     ],
 )
 
@@ -36,6 +36,6 @@ py_library(
     ],
     deps = [
         "//examples/helloworld/proto:py",
-        package("grpcio"),
+        requirement("grpcio"),
     ],
 )


### PR DESCRIPTION
This renames `package` to `requirement` to avoid a conflict with a Bazel built-in function.