### PR TITLE
Update output path calculation for generated protos

### DIFF
--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -185,6 +185,12 @@ def _build_output_files(run, builder):
       base = _capitalize(base)
     for ext in exts:
       path = _get_relative_dirname(run, ctx.label.package, file)
+
+      if ctx.var["GENDIR"].endswith("/".join(path)):
+         # if the path context is the genfiles directory, ignore relative
+         # path name calculation
+         path = []
+
       path.append(base + ext)
       pbfile = ctx.new_file("/".join(path))
       builder["outputs"] += [pbfile]


### PR DESCRIPTION
This PR is the companion PR to #118 .  It probably should have been part of that PR.

The issue:
When generating code from generated proto files, output path calculation can lead to incorrect results. This manifests as error messages indicating that the expected output file has not been generated. Example error:

> ERROR: .../BUILD:7:1: output 'local-fastbuild/genfiles/go_default_library_tmpl.pb.go' was not created.
ERROR: .../BUILD:7:1: not all outputs were created or valid. 

This PR edits the calculated output path in `_build_output_files`. When the calculated relative dirname for the output path ends with `ctx.var["GENDIR"]`, this change sets the path to `[]`. This should ensure that files generated from generated files are not placed in nested GENDIRs.

Same BUILD run with this change:

> Target //:go_default_library up-to-date:
  bazel-bin/\~lib\~/.../report.a
INFO: Elapsed time: 52.429s, Critical Path: 9.41s