### PR TITLE
Update genfiles path calculation logic

### DIFF
--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -186,10 +186,10 @@ def _build_output_files(run, builder):
     for ext in exts:
       path = _get_relative_dirname(run, ctx.label.package, file)
 
-      if ctx.var["GENDIR"].endswith("/".join(path)):
-         # if the path context is the genfiles directory, ignore relative
-         # path name calculation
-         path = []
+      genpath = ctx.var["GENDIR"].split("/")
+      lastIndex = len(genpath) - 1
+      if genpath[lastIndex] in path:
+        path = []
 
       path.append(base + ext)
       pbfile = ctx.new_file("/".join(path))


### PR DESCRIPTION
cc: @guptasu (who has been my partner in crime in an evolving use case for these updates).

In the prior PR (https://github.com/pubref/rules_protobuf/pull/128), we updated the calculated path to be `[]` when the relative dir was *exactly* `ctx.var["GENDIR"]`. This achieves the desired effect when dealing with generated protos at the *root* of genfiles.

However, in cases when the generated proto is in subdirectories of genfiles (like in the case of external protos in cross-repo scenarios), this is not sufficient.

This PR solves this issue by searching for the final part of the `ctx.var["GENDIR"]` in `path`. If found, it sets the path to '[]' as before.

Python is NOT my strong suit, so there might be a more eloquent expression of the goal, but this seems to work in testing.

If there is a better way than looking for, in all likelihood `genfiles`, in the path, I'd love to improve this rough heuristic.

Verbose logs for motivating case:
```
 ************************************************************
cd $(bazel info execution_root) && bazel-out/host/bin/external/com_github_google_protobuf/protoc \
--descriptor_set_out=bazel-out/darwin_x86_64-fastbuild/genfiles/external/com_github_guptasu_report/go_default_library_gogo_proto.pb.descriptor_set \
...
--gogoslick_out=...plugins=grpc:. \
...
bazel-out/darwin_x86_64-fastbuild/genfiles/external/com_github_guptasu_report/go_default_library_tmpl.proto
************************************************************
../com_github_guptasu_report/darwin_x86_64-fastbuild/genfiles/external/com_github_guptasu_report/go_default_library_tmpl.pb.go
../com_github_guptasu_report/go_default_library_gogo_proto.pb.descriptor_set
 ************************************************************
```

This would lead to errors like:
> ERROR: .../external/com_github_guptasu_report/BUILD:7:1: output 'external/com_github_guptasu_report/external/com_github_guptasu_report/go_default_library_tmpl.pb.go' was not created.

This issue is resolved by this PR.