### PR TITLE
Align Protobuf dependency with upstream 3.4.0 tag

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -5,7 +5,7 @@ To update this list, `bazel build @org_pubref_rules_protobuf//:deps && cp bazel-
 
 | Rule | Workspace | Detail |
 | ---: | :--- | :--- |
-| [http_archive](https://docs.bazel.build/versions/master/be/workspace.html#http_archive) | **`@com_google_protobuf`** | [sha256:e83ee63eccfb](https://github.com/google/protobuf/archive/2807436cd828a526c5c38dd235c0d0d9cdc67b1f.zip) |
+| [http_archive](https://docs.bazel.build/versions/master/be/workspace.html#http_archive) | **`@com_google_protobuf`** | [sha256:542703acadc3](https://github.com/google/protobuf/archive/v3.4.0.zip) |
 | [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@protoc`** | `//external:protoc` (`@com_google_protobuf//:protoc`) |
 | [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@protocol_compiler`** | `//external:protocol_compiler` (`@com_google_protobuf//:protoc`) |
 | [bind](https://docs.bazel.build/versions/master/be/workspace.html#bind) | **`@protobuf`** | `//external:protobuf` (`@com_google_protobuf//:protobuf`) |

--- a/protobuf/deps.bzl
+++ b/protobuf/deps.bzl
@@ -5,9 +5,9 @@ DEPS = {
     # Building grpc requires it to be called thusly.
     "com_google_protobuf": {
         "rule": "http_archive",
-        "url": "https://github.com/google/protobuf/archive/2807436cd828a526c5c38dd235c0d0d9cdc67b1f.zip", # 3.4.0
-        "strip_prefix": "protobuf-2807436cd828a526c5c38dd235c0d0d9cdc67b1f",
-        "sha256": "e83ee63eccfb47f07f263fbcdea0a2d838dab4a750c53867013539b5e536dd8a",
+        "url": "https://github.com/google/protobuf/archive/v3.4.0.zip",
+        "strip_prefix": "protobuf-3.4.0",
+        "sha256": "542703acadc3f690d998f4641e1b988f15ba57ebca05fdfb1cd9095bec007948",
     },
 
     # This binds the cc_binary "protoc" into


### PR DESCRIPTION
Using a different SHA than the upstream 3.4.0 tag causes dependency problems
in larger projects that already have com_google_protobuf v3.4.0 in their WORKSPACE.