### PR TITLE
Change generate_cc.bzl to avoid using colon when unnecessary

### DIFF
--- a/cpp/generate_cc.modified.bzl
+++ b/cpp/generate_cc.modified.bzl
@@ -26,6 +26,8 @@ we shift into the external workspace with a 'cd
 external/com_google_grpc', and adjust dir_out, plugin_out,
 cpp_out etc to be relative to the forward shifted position.
 
+Third change: Windows compatibility by not including : when unnecessary.
+
 """
 
 def generate_cc_impl(ctx):
@@ -55,10 +57,16 @@ def generate_cc_impl(ctx):
     flags = list(ctx.attr.flags)
     if ctx.attr.generate_mock:
       flags.append("generate_mock_code=true")
-    arguments += ["--PLUGIN_out=" + ",".join(flags) + ":" + dir_out]
+    if flags:
+      arguments += ["--PLUGIN_out=" + ",".join(flags) + ":" + dir_out]
+    else:
+      arguments += ["--PLUGIN_out=" + dir_out]
     additional_input = [ctx.executable.plugin]
   else:
-    arguments += ["--cpp_out=" + ",".join(ctx.attr.flags) + ":" + dir_out]
+    if ctx.attr.flags:
+      arguments += ["--cpp_out=" + ",".join(ctx.attr.flags) + ":" + dir_out]
+    else:
+      arguments += ["--cpp_out=" + dir_out]
     additional_input = []
 
   #arguments += ["-I{0}={0}".format(include.path) for include in includes]


### PR DESCRIPTION
`generate_cc.bzl` creates rules that call `protoc` with options like `--cpp_out=:some/path`.  This is the form that `protoc` expects to take, and it is usually fine.  However, on Windows, Bazel runs commands through an MSYS shell, and when executing Windows-native commands, MSYS tries to translate anything that looks POSIXy to be Windowsy.  Unfortunately, here its heuristics kick in, thinking it looks like a POSIXy colon-delimited PATH, and converts the colon to a semicolon, which is then misinterpreted by `protoc`.

When there are no options, we omit the colon, which avoids this error when building on Windows.  This still doesn't solve the case when options do need to be passed, but fortunately that case has not yet come up for us, so this is an acceptable stopgap solution.