### PR TITLE
Add hacky support for interpolating $(GENDIR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,15 @@ performs the code generation step.  For example, the
 attribute to accomplish both code generation and compilation of object
 files for the proto chain.
 
+### Generated Imports
+
+If the protobuf schema is not part of your workspace, but rather generated
+via a genrule or similar, you can interpolate the import path for that
+file by using the special `$(GENDIR)` variable.  For example, if there
+is a genrule in `//foo/bar:generated_proto`, you can add
+`$(GENDIR)/foo/bar` to the `imports` list to make the generated file
+visible to `protoc` for compilation.
+
 ### External Imports
 
 The same logic applies to external imports.  The two questions to ask

--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -559,7 +559,7 @@ def _proto_compile_impl(ctx):
   # Mutable global state to be populated by the classes.
   builder = {
     "args": [], # list of string
-    "imports": ctx.attr.imports + ["."],
+    "imports": [i.replace("$(GENDIR)", ctx.genfiles_dir.path) for i in ctx.attr.imports] + ["."],
     "inputs": ctx.files.protos + ctx.files.inputs,
     "outputs": [],
     "commands": [], # optional miscellaneous pre-protoc commands


### PR DESCRIPTION
There is currently no way to compile protobuf schema files that are generated by a genrule, because they will be placed into `ctx.genfiles_dir`, which is not possible to add to the `"imports"` attribute in the standard rules as defined by this repository.

This change is a bit hacky, but it solves this specific use-case of being able to refer to the gendir of a specific genrule.  You can write `"imports": "$(GENDIR)/proto"` for gendir rules that are in the `//proto` package.

If anyone can propose an alternate solution, please feel free to comment!