### PR TITLE
Sample for testing objc protocol dependencies.

### DIFF
--- a/objc/rules.bzl
+++ b/objc/rules.bzl
@@ -17,7 +17,7 @@ def objc_proto_repositories(
                      **kwargs)
 
 PB_COMPILE_DEPS = [
-    "@com_google_protobuf//:protobuf_objc",
+    "@com_google_protobuf//:objectivec",
 ]
 
 GRPC_COMPILE_DEPS = PB_COMPILE_DEPS + [

--- a/tests/objc_proto_dep_test/BUILD
+++ b/tests/objc_proto_dep_test/BUILD
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//objc:rules.bzl", "objc_proto_library")
+
+objc_proto_library(
+   name = "lib1",
+   protos = ["lib1.proto"],
+   with_grpc = False,
+)
+
+objc_proto_library(
+   name = "lib2",
+   protos = ["lib2.proto"],
+   proto_deps = [":lib1"],   
+   imports = ["."],
+   with_grpc = False,
+)
+

--- a/tests/objc_proto_dep_test/lib1.proto
+++ b/tests/objc_proto_dep_test/lib1.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package lib1;
+
+message Message1 {
+  string test1 = 1;
+}

--- a/tests/objc_proto_dep_test/lib2.proto
+++ b/tests/objc_proto_dep_test/lib2.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package lib2;
+
+import "tests/objc_proto_dep_test/lib1.proto";
+
+message Message2 {
+  lib1.Message1 message1 = 1;
+  string test2 = 2;
+}
+


### PR DESCRIPTION
Note that "@com_google_protobuf//:protobuf_objc" does not work anymore.  So needed to use "@com_google_protobuf//:objectivec"