### PR TITLE
Update proto_language Readme

### DIFF
--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -72,7 +72,7 @@ to generate custom library outputs.
 | `grpc_compile_deps` | `label_list` | Optional list of dependencies for a library rule. Currently only supported for java-based rules. | `[]` |
 | `grpc_runtime_deps` | `label_list` | Optional list of dependencies for a binary rule. Currently only supported for java-based rules. | `[]` |
 | `pb_plugin_implements_grpc` | `bool` | Optional flag if the plugin generates both grpc and non-grpc related outputs. | `[]` |
-| `prefix` | `label` providing `go_prefix` | Optional label to the go_prefix rule (go specific). | `""` |
+| `go_prefix` | `label` providing `go_prefix` | Optional label to the go_prefix rule (go specific). | `""` |
 | `importmap` | `string_dict`  | Optional mappings (go specific). | `{}` |
 
 ---


### PR DESCRIPTION
There is a bug in the `proto_language` documentation, `prefix` is not a valid argument to the `proto_language` rule: https://github.com/pubref/rules_protobuf/blob/master/protobuf/internal/proto_language.bzl#L34

It seems like it's changed to `go_prefix` here: https://github.com/pubref/rules_protobuf/commit/0708c69ada41afbeca7b8c35a643518147471a92