### PR TITLE
Update to rules_go 0.7.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ os:
 
 env:
   - V=0.7.0
-  - V=0.5.4
-  - V=0.5.2
+  - V=0.6.1
 
 before_install:
   - OS=linux
@@ -28,7 +27,6 @@ before_install:
   - chmod +x install.sh
   - ./install.sh --user
   - rm -f install.sh
-  - sudo pip install grpcio==1.6.0
 
 script:
   - make all

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,15 +8,17 @@ load("//protobuf:rules.bzl", "github_archive")
 
 github_archive(
     name = "io_bazel_rules_go",
-    commit = "ae70411645c171b2056d38a6a959e491949f9afe",  # v0.5.4
+    commit = "6d900bc95ae678bec5c91031b8e987957d2a7f93",  # post-0.7.0 (includes important cross-compile fixes)
     org = "bazelbuild",
     repo = "rules_go",
-    sha256 = "ae91c1dfe9b943500f7486f2bb94b9887f881c7709474f3e170c95d414f79698",
+    sha256 = "d36baba631b29151434726eb204fa93ce8793b5f8ef96da452f382d77bd95c93",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 
-go_repositories()
+go_rules_dependencies()
+
+go_register_toolchains()
 
 # ================================================================
 # closure js_proto_library support requires rules_closure

--- a/protobuf/internal/proto_repositories.bzl
+++ b/protobuf/internal/proto_repositories.bzl
@@ -12,6 +12,7 @@ def proto_repositories(excludes = [],
                          "protocol_compiler",
                        ],
                        overrides = {},
+                       strict = True,
                        verbose = 0):
   return require(
     keys = protobuf_requires + lang_requires,
@@ -19,4 +20,5 @@ def proto_repositories(excludes = [],
     excludes = excludes,
     overrides = overrides,
     verbose = verbose,
+    strict = strict,
   )


### PR DESCRIPTION
Adds a check in the require function to avoid strictness
if the pre-existing rule does not have a sha value set
(where strict is defined as "fail if we try to re-load / override
an external dependency where the sha256 values for the
rule don't match").

Removes 0.5.x from travis matrix and removes residual pip
dependency.