### PR TITLE
Bump gogo version and disable go_proto_library generation by rules_go

### DIFF
--- a/gogo/deps.bzl
+++ b/gogo/deps.bzl
@@ -3,7 +3,8 @@ DEPS = {
   "com_github_gogo_protobuf": {
       "rule": "go_repository",
       "importpath": "github.com/gogo/protobuf",
-      "commit": "100ba4e885062801d56799d78530b73b178a78f3", # Mar 7, 2017
+      "commit": "616a82ed12d78d24d4839363e8f3c5d3f20627cf", # Nov 9, 2017
+      "build_file_proto_mode": "disable",
   },
 
 }


### PR DESCRIPTION
This change bumps the version of gogo to include https://github.com/gogo/protobuf/pull/350, and also disables the `go_proto_library` rule generation now enabled by default in `rules_go`.

For `@gogo//gogoproto`, the generated `go_proto_library` rule contains an incorrect golang/protobuf dependency (see below). The generated `go_proto_library` rule is not necessary since gogoproto has already generated gogo.pb.go and included it in the repo.

```
external/com_github_gogo_protobuf/gogoproto/helper.go:35:37: cannot use E_Embed (type *"github.com/golang/protobuf/proto".ExtensionDesc) as type *"github.com/gogo/protobuf/proto".ExtensionDesc in argument to "github.com/gogo/protobuf/proto".GetBoolExtension
external/com_github_gogo_protobuf/gogoproto/helper.go:39:37: cannot use E_Nullable (type *"github.com/golang/protobuf/proto".ExtensionDesc) as type *"github.com/gogo/protobuf/proto".ExtensionDesc in argument to "github.com/gogo/protobuf/proto".GetBoolExtension
external/com_github_gogo_protobuf/gogoproto/helper.go:43:37: cannot use E_Stdtime (type *"github.com/golang/protobuf/proto".ExtensionDesc) as type *"github.com/gogo/protobuf/proto".ExtensionDesc in argument to "github.com/gogo/protobuf/proto".GetBoolExtension
external/com_github_gogo_protobuf/gogoproto/helper.go:47:37: cannot use E_Stdduration (type *"github.com/golang/protobuf/proto".ExtensionDesc) as type *"github.com/gogo/protobuf/proto".ExtensionDesc in argument to "github.com/gogo/protobuf/proto".GetBoolExtension
external/com_github_gogo_protobuf/gogoproto/helper.go:94:36: cannot use E_Enumdecl (type *"github.com/golang/protobuf/proto".ExtensionDesc) as type *"github.com/gogo/protobuf/proto".ExtensionDesc in argument to "github.com/gogo/protobuf/proto".GetBoolExtension
external/com_github_gogo_protobuf/gogoproto/helper.go:94:85: cannot use E_EnumdeclAll (type *"github.com/golang/protobuf/proto".ExtensionDesc) as type *"github.com/gogo/protobuf/proto".ExtensionDesc in argument to "github.com/gogo/protobuf/proto".GetBoolExtension
external/com_github_gogo_protobuf/gogoproto/helper.go:98:39: cannot use E_Typedecl (type *"github.com/golang/protobuf/proto".ExtensionDesc) as type *"github.com/gogo/protobuf/proto".ExtensionDesc in argument to "github.com/gogo/protobuf/proto".GetBoolExtension
external/com_github_gogo_protobuf/gogoproto/helper.go:98:88: cannot use E_TypedeclAll (type *"github.com/golang/protobuf/proto".ExtensionDesc) as type *"github.com/gogo/protobuf/proto".ExtensionDesc in argument to "github.com/gogo/protobuf/proto".GetBoolExtension
external/com_github_gogo_protobuf/gogoproto/helper.go:106:37: cannot use E_Customtype (type *"github.com/golang/protobuf/proto".ExtensionDesc) as type *"github.com/gogo/protobuf/proto".ExtensionDesc in argument to "github.com/gogo/protobuf/proto".GetExtension
external/com_github_gogo_protobuf/gogoproto/helper.go:119:37: cannot use E_Casttype (type *"github.com/golang/protobuf/proto".ExtensionDesc) as type *"github.com/gogo/protobuf/proto".ExtensionDesc in argument to "github.com/gogo/protobuf/proto".GetExtension
```