### PR TITLE
Add prebuilt Java gRPC dependency for Windows

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -121,6 +121,8 @@ genrule(
     name = "protoc_gen_grpc_java_bin",
     srcs = select({
         ":darwin": ["@protoc_gen_grpc_java_macosx//file"],
+        ":windows": ["@protoc_gen_grpc_java_windows_x86_64//file"],
+        ":windows_msvc": ["@protoc_gen_grpc_java_windows_x86_64//file"],
         "//conditions:default": ["@protoc_gen_grpc_java_linux_x86_64//file"],
     }),
     outs = ["protoc_gen_grpc_java"],
@@ -137,7 +139,19 @@ genrule(
 
 config_setting(
     name = "darwin",
-    values = {"cpu": "darwin"},
+    values = {"host_cpu": "darwin"},
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "windows",
+    values = {"host_cpu": "x64_windows"},
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "windows_msvc",
+    values = {"host_cpu": "x64_windows_msvc"},
     visibility = ["//visibility:private"],
 )
 

--- a/java/deps.bzl
+++ b/java/deps.bzl
@@ -30,6 +30,12 @@ DEPS = {
         "sha256": "a9fdb363d05786c00541f83893cd34566bdc92e8d5355d6123d93c2b2885795d",
     },
 
+    "protoc_gen_grpc_java_windows_x86_64": {
+        "rule": "http_file",
+        "url": "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.7.0/protoc-gen-grpc-java-1.7.0-windows-x86_64.exe",
+        "sha256": "e579866c7ec42dd27838960abedb32bfc41debfa9ae0b9d45a286f1011ce5c43",
+    },
+
     # ######################
     # Maven Dependencies #
     # ######################

--- a/java/rules.bzl
+++ b/java/rules.bzl
@@ -14,6 +14,7 @@ def java_proto_repositories(
 
     "protoc_gen_grpc_java_linux_x86_64",
     "protoc_gen_grpc_java_macosx",
+    "protoc_gen_grpc_java_windows_x86_64",
 
     'com_google_api_grpc_proto_google_common_protos',
     'com_google_code_findbugs_jsr305',


### PR DESCRIPTION
Also specify the OS-sniffing `config_setting` to use `host_cpu` rather than `cpu`, as the `proto_compile` actions are specified to run in the host context.