### PR TITLE
Allow overriding implicit cpp repositories options in other language rules

### DIFF
--- a/csharp/rules.bzl
+++ b/csharp/rules.bzl
@@ -13,7 +13,7 @@ def csharp_proto_repositories(
     ], **kwargs):
 
   if not omit_cpp_repositories:
-    cpp_proto_repositories()
+    cpp_proto_repositories(**kwargs)
 
   rem = proto_repositories(lang_deps = lang_deps,
                            lang_requires = lang_requires,

--- a/node/rules.bzl
+++ b/node/rules.bzl
@@ -17,7 +17,7 @@ def node_proto_repositories(
     **kwargs):
 
   if not omit_cpp_repositories:
-    cpp_proto_repositories()
+    cpp_proto_repositories(**kwargs)
 
   rem = proto_repositories(lang_deps = lang_deps,
                            lang_requires = lang_requires,

--- a/objc/rules.bzl
+++ b/objc/rules.bzl
@@ -10,7 +10,7 @@ def objc_proto_repositories(
     ], **kwargs):
 
   if not omit_cpp_repositories:
-    cpp_proto_repositories()
+    cpp_proto_repositories(**kwargs)
 
   proto_repositories(lang_deps = lang_deps,
                      lang_requires = lang_requires,

--- a/python/rules.bzl
+++ b/python/rules.bzl
@@ -10,7 +10,7 @@ def py_proto_repositories(
     ], **kwargs):
 
   if not omit_cpp_repositories:
-    cpp_proto_repositories()
+    cpp_proto_repositories(**kwargs)
 
   proto_repositories(lang_deps = lang_deps,
                      lang_requires = lang_requires,

--- a/ruby/rules.bzl
+++ b/ruby/rules.bzl
@@ -10,7 +10,7 @@ def ruby_proto_repositories(
     ], **kwargs):
 
   if not omit_cpp_repositories:
-    cpp_proto_repositories()
+    cpp_proto_repositories(**kwargs)
 
   proto_repositories(lang_deps = lang_deps,
                      lang_requires = lang_requires,


### PR DESCRIPTION
This shows up when using a different version of google test to the one protobuf expects to be built with.

An alternative is to explicitly call `cpp_proto_repositories()`, passing any necessary arguments first (`overrides` in this case) and then call eg. `python_proto_repositories(omit_cpp_repositories=True)`. This is less obvious without reading the bazel rules themselves.

For reference, the error was:

```
An existing http_archive rule 'com_google_googletest' was already loaded with a sha256 value of '...'.  Refusing to overwrite this with the requested value ('f87029f647276734ef076785f76652347993b6d13ac1cbb2d2e976e16d2f8137').
Either remove the pre-existing rule from your WORKSPACE or exclude it from loading by rules_protobuf.
```