### PR TITLE
Fix the Python build by updating the dotnet import.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,10 +42,10 @@ closure_repositories()
 
 github_archive(
     name = "io_bazel_rules_dotnet",
-    commit = "ebc7c1cb61d45bd57042c60b6bfabdfff4979466",
+    commit = "1a6ca96fe05bca83782464453ac4657fb8ed8379",
     org = "bazelbuild",
     repo = "rules_dotnet",
-    sha256 = "b50c4a1133dfa834fab5ff7596e67866f67e252f76649543adca5f0c3fdec140",
+    sha256 = "0f7d7f79bf543fdcce9ffebf422df2f858eae63367869b441d4d1005f279fa1f",
 )
 
 load("@io_bazel_rules_dotnet//dotnet:csharp.bzl", "csharp_repositories")

--- a/node/deps.bzl
+++ b/node/deps.bzl
@@ -8,9 +8,9 @@ DEPS = {
     "npm_protobuf_stack": {
         "rule": "npm_repository",
         "deps": {
-            "async": "1.5.2",
-            "google-protobuf": "3.1.1",
-            "lodash": "4.6.1",
+            "async": "2.6.0",
+            "google-protobuf": "3.5.0",
+            "lodash": "4.17.5",
             "minimist": "1.2.0",
         },
         "sha256": "96242be14d18d9f1e81603502893545c7ca0fbcabcb9e656656cbcdda2b52bbb",

--- a/protobuf/deps.bzl
+++ b/protobuf/deps.bzl
@@ -5,9 +5,9 @@ DEPS = {
     # Building grpc requires it to be called thusly.
     "com_google_protobuf": {
         "rule": "http_archive",
-        "url": "https://github.com/google/protobuf/archive/v3.4.0.zip",
-        "strip_prefix": "protobuf-3.4.0",
-        "sha256": "542703acadc3f690d998f4641e1b988f15ba57ebca05fdfb1cd9095bec007948",
+        "url": "https://github.com/google/protobuf/archive/v3.5.1.zip",
+        "strip_prefix": "protobuf-3.5.1",
+        "sha256": "42667f11248caa7eb4637a37cc45eab86c436e9c3abd353beba2c0ab4f7cd13b",
     },
 
     # This binds the cc_binary "protoc" into


### PR DESCRIPTION
With a recent build of bazel, the HEAD revision no longer builds:

```
~/src/github/pubref/rules_protobuf$ bazel build python
.
ERROR: /external/io_bazel_rules_dotnet/dotnet/csharp.bzl:25:10: The function 'set' has been removed in favor of 'depset', please use the latter. You can temporarily refer to the old 'set' constructor from unexecuted code by using --incompatible_disallow_uncalled_set_constructor=false
ERROR: error loading package '': Extension 'dotnet/csharp.bzl' has errors
ERROR: error loading package '': Extension 'dotnet/csharp.bzl' has errors
INFO: Elapsed time: 1.290s
FAILED: Build did NOT complete successfully (0 packages loaded)

```