### PR TITLE
Fixing proto compiles from WORKSPACE root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore all bazel-* symlinks. There is no full list since this can change
 # based on the name of the directory bazel is cloned into.
 /bazel-*
+/tests/build_in_workspace_root/bazel-*

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test_gogo:
 
 all: build test
 
-build: external_proto_library_build
+build: external_proto_library_build workspace_root_build
 	$(BAZEL_BUILD) \
 	//examples/extra_args:person_tar \
 	//examples/helloworld/node:client \
@@ -72,6 +72,8 @@ test: test_pip_dependent_targets test_gogo
 external_proto_library_build:
 	cd tests/external_proto_library && $(BAZEL_BUILD) :cc_gapi :go_gapi :java_gapi
 
+workspace_root_build:
+	cd tests/build_in_workspace_root && $(BAZEL_BUILD) :bar_proto
 fmt:
 	buildifier WORKSPACE
 	buildifier BUILD

--- a/tests/build_in_workspace_root/BUILD
+++ b/tests/build_in_workspace_root/BUILD
@@ -1,0 +1,7 @@
+load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cc_proto_compile")
+
+cc_proto_compile(
+    name = "bar_proto",
+    protos = ["foo/bar.proto"],
+    with_grpc = True,
+)

--- a/tests/build_in_workspace_root/WORKSPACE
+++ b/tests/build_in_workspace_root/WORKSPACE
@@ -1,0 +1,8 @@
+local_repository(
+    name = "org_pubref_rules_protobuf",
+    path = "../..",
+)
+
+load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_repositories")
+cpp_proto_repositories()
+

--- a/tests/build_in_workspace_root/foo/bar.proto
+++ b/tests/build_in_workspace_root/foo/bar.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package foo;
+
+message Bar {
+    string data = 1;
+}


### PR DESCRIPTION
Fixing a bug that enables BUILD files in workspace root to build protos in directories.  (#201)

I've also provided a test.