### PR TITLE
Fix proto_path to handle generated sources

### DIFF
--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -549,6 +549,15 @@ def _check_if_protos_are_generated(ctx):
     """
   )
 
+def  _add_imports_for_transitive_units(ctx, data, builder):
+  proto_paths = [ data.execdir ]
+  for unit in data.transitive_units:
+    if len(unit.data.protos) == 0:
+      continue
+    if unit.data.execdir not in proto_paths:
+      builder["imports"].append(_get_offset_path(data.execdir, unit.data.execdir))
+      proto_paths.append(unit.data.execdir)
+
 
 def _proto_compile_impl(ctx):
 
@@ -631,6 +640,8 @@ def _proto_compile_impl(ctx):
     "outputs": [],
     "commands": [], # optional miscellaneous pre-protoc commands
   }
+
+  _add_imports_for_transitive_units(ctx, data, builder)
 
   # Build a list of structs that will be processed in this compiler
   # run.

--- a/tests/generated_proto_file/BUILD
+++ b/tests/generated_proto_file/BUILD
@@ -55,3 +55,58 @@ cpp_proto_library(
    with_grpc = True,
    verbose = 0,
 )
+
+genrule(
+     name = "complicated_copy_proto",
+     srcs = ["complicated/complicated.proto"],
+     outs = ["complicated/comp_copy.proto"],
+     cmd = "cat $< > $@",
+     message = "copy",
+)
+
+genrule(
+     name = "complicated_copy_proto_copy",
+     srcs = ["complicated/complicated_copy.proto"],
+     outs = ["complicated/comp_copy2.proto"],
+     cmd = "cat $< > $@",
+     message = "copy",
+)
+
+cpp_proto_library(
+   name = "complicated_default_library",
+   protos = ["complicated/complicated.proto"],
+   verbose = 0,
+   proto_deps = [
+      ":subdir_default_library",
+   ],
+   inputs = [
+      "@com_google_protobuf//:well_known_protos",
+   ],
+)
+
+cpp_proto_library(
+   name = "complicated_default_library_on_gen",
+   protos = ["complicated/complicated_copy.proto"],
+   verbose = 0,
+   proto_deps = [
+      ":subdir_copy_library",
+   ],
+)
+
+cpp_proto_library(
+   name = "complicated_copy_library",
+   protos = [":complicated_copy_proto"],
+   verbose = 0,
+   proto_deps = [
+      ":subdir_default_library",
+   ],
+)
+
+cpp_proto_library(
+   name = "complicated_copy_library_on_gen",
+   protos = [":complicated_copy_proto_copy"],
+   verbose = 0,
+   proto_deps = [
+      ":subdir_copy_library",
+   ],
+)

--- a/tests/generated_proto_file/complicated/complicated.proto
+++ b/tests/generated_proto_file/complicated/complicated.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+import "tests/generated_proto_file/subdir/simple.proto";
+
+package complicated;
+
+message Test {
+    subdir.Test test = 1;
+}
+

--- a/tests/generated_proto_file/complicated/complicated_copy.proto
+++ b/tests/generated_proto_file/complicated/complicated_copy.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+import "tests/generated_proto_file/subdir/copy.proto";
+
+package complicated;
+
+message Test {
+    subdir.Test test = 1;
+}

--- a/tests/generated_proto_file/subdir/simple.proto
+++ b/tests/generated_proto_file/subdir/simple.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package simple;
+package subdir;
 
 message Test {
     string value = 1;


### PR DESCRIPTION
Automatically update the proto_path when dealing with a mixture of generated and non-generated proto sources.

This also automatically adds external rules that you depend on to the proto_path.