### PR TITLE
Fix issue 142

### DIFF
--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -195,7 +195,7 @@ def _build_output_files(run, builder):
     fail("Empty proto input list.", "protos")
 
   exts = run.exts
-  
+
   for file in protos:
     base = file.basename[:-len(".proto")]
     if run.lang.output_file_style == 'pascal':

--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -191,13 +191,18 @@ def _build_output_files(run, builder):
     fail("Empty proto input list.", "protos")
 
   exts = run.exts
-
+  
+  build_path = ctx.build_file_path[:-len("BUILD")]
   for file in protos:
     base = file.basename[:-len(".proto")]
     if run.lang.output_file_style == 'pascal':
       base = _pascal_case(base)
     if run.lang.output_file_style == 'capitalize':
       base = _capitalize(base)
+
+    # prepend offset between BUILD directory and file directory
+    if file.path.startswith(build_path):
+      base = file.path[len(build_path):-len(file.basename)] + base
 
     # If the source is a generated file, prefix the build file path with GENDIR
     generated_path = ctx.var["GENDIR"]

--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -83,6 +83,10 @@ def _get_relative_dirname(run, base, file):
     return parts
 
   if not path.startswith(base):
+    build_path = run.ctx.build_file_path[:-len("BUILD")]
+    # prepend offset between BUILD directory and file directory
+    if file.path.startswith(build_path):
+      return file.path[len(build_path):-len(file.basename)].split("/")
     #TODO is this a failing error?
     return []
 
@@ -192,17 +196,12 @@ def _build_output_files(run, builder):
 
   exts = run.exts
   
-  build_path = ctx.build_file_path[:-len("BUILD")]
   for file in protos:
     base = file.basename[:-len(".proto")]
     if run.lang.output_file_style == 'pascal':
       base = _pascal_case(base)
     if run.lang.output_file_style == 'capitalize':
       base = _capitalize(base)
-
-    # prepend offset between BUILD directory and file directory
-    if file.path.startswith(build_path):
-      base = file.path[len(build_path):-len(file.basename)] + base
 
     # If the source is a generated file, prefix the build file path with GENDIR
     generated_path = ctx.var["GENDIR"]


### PR DESCRIPTION
potential fix for https://github.com/pubref/rules_protobuf/issues/142
relative path to target file is lost if file path does not start with base.
this always occurs when building from external since external working dir ditches external prefix.
e.g.: ".../external/a/b/c.proto" with BUILD at a has base a, a != external, so we return []
Instead we ignore base and take relative path from BUILD directory to file. (not sure why not use this in the first place)
There may exist more elegant solution.

Without this fix, depending on external pb libraries built with rules_protobuf will fail without complete restructuring.