### PR TITLE
Fix root attr on proto_compile

### DIFF
--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -409,6 +409,9 @@ def _get_outdir(ctx, data):
   if execdir != ".":
     path += "/" + execdir
 
+  if ctx.attr.root:
+    path += "/" + ctx.attr.root
+
   return path
 
 


### PR DESCRIPTION
Hey, I noticed that `root` attr is defined and documented for `proto_compile` but not used in code. Let me know if this is the right way to fix it.