### PR TITLE
Remove FileType

### DIFF
--- a/protobuf/internal/proto_compile.bzl
+++ b/protobuf/internal/proto_compile.bzl
@@ -742,7 +742,7 @@ proto_compile = rule(
       mandatory = False,
     ),
     "protos": attr.label_list(
-      allow_files = FileType([".proto"]),
+      allow_files = [".proto"],
     ),
     "includes": attr.string_list(),
     "excludes": attr.string_list(),


### PR DESCRIPTION
Bazel has deprecated `FileType`, and will be removing it. It is no longer needed. See https://github.com/bazelbuild/bazel/releases/tag/0.14.0