### PR TITLE
[travis] remove 0.8.0, add 0.15.2, use 0.13.1, 0.14.1, and allow osx failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ os:
   - osx
 
 env:
-  - V=0.14.0
-  - V=0.13.0
+  - V=0.15.2
+  - V=0.14.1
+  - V=0.13.1
   - V=0.12.0
-  - V=0.8.0
 
 before_install:
   - OS=linux
@@ -35,3 +35,7 @@ script:
 
 notifications:
   email: false
+
+matrix:
+  allow_failures:
+  - os: osx # currently fails on //examples/helloworld/cpp:test


### PR DESCRIPTION
Some Travis updates to accommodate newer versions of Bazel and make builds green again:

- rules_protobuf currently fails on Bazel 0.8.0. Since it is quite an old version of Bazel, it probably makes more sense for the project to stop supporting.
- Test against latest bugfix versions of Bazel 0.13.x and 0.14.x.
- Test against Bazel 0.15.x. (Omitting 0.16.x since it seems to have some problems with the embedded JDK. Should test against 0.17.x when it's released to address some of 0.16.x's woes more systemically)
- Allow OS X tests to fail for now to have the build be green. It was broken by the gRPC upgrade in https://github.com/pubref/rules_protobuf/pull/212 and can probably be fixed by using a newer version of gRPC.